### PR TITLE
[Feat/#160] 카카오 로그인 구현

### DIFF
--- a/Roomie/Roomie.xcodeproj/project.pbxproj
+++ b/Roomie/Roomie.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		42D5EA59A4989AF59719BD17 /* libPods-Roomie.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2333A10B8CCAE5AB88BA7974 /* libPods-Roomie.a */; };
+		A3128C052DE4A2B800DA4CA7 /* KakaoSDK in Frameworks */ = {isa = PBXBuildFile; productRef = A3128C042DE4A2B800DA4CA7 /* KakaoSDK */; };
+		A3128C072DE4A2B800DA4CA7 /* KakaoSDKAuth in Frameworks */ = {isa = PBXBuildFile; productRef = A3128C062DE4A2B800DA4CA7 /* KakaoSDKAuth */; };
+		A3128C092DE4A2B800DA4CA7 /* KakaoSDKCommon in Frameworks */ = {isa = PBXBuildFile; productRef = A3128C082DE4A2B800DA4CA7 /* KakaoSDKCommon */; };
 		A346BD422D2E23F0002BA445 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = A346BD412D2E23F0002BA445 /* SnapKit */; };
 		A346BD452D2E23FD002BA445 /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = A346BD442D2E23FD002BA445 /* Then */; };
 		A346BD482D2E2449002BA445 /* Moya in Frameworks */ = {isa = PBXBuildFile; productRef = A346BD472D2E2449002BA445 /* Moya */; };
@@ -16,6 +20,7 @@
 
 /* Begin PBXFileReference section */
 		0ABCF9387F76F9D8837E2F9E /* Pods-Roomie.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Roomie.debug.xcconfig"; path = "Target Support Files/Pods-Roomie/Pods-Roomie.debug.xcconfig"; sourceTree = "<group>"; };
+		2333A10B8CCAE5AB88BA7974 /* libPods-Roomie.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Roomie.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		A346BA412D2CDF13002BA445 /* Roomie.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Roomie.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C8959DCCF833BE3AC6F237CE /* Pods-Roomie.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Roomie.release.xcconfig"; path = "Target Support Files/Pods-Roomie/Pods-Roomie.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -46,11 +51,15 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A3128C092DE4A2B800DA4CA7 /* KakaoSDKCommon in Frameworks */,
+				A3128C072DE4A2B800DA4CA7 /* KakaoSDKAuth in Frameworks */,
 				A346BD4B2D2E2477002BA445 /* Kingfisher in Frameworks */,
 				A346BD422D2E23F0002BA445 /* SnapKit in Frameworks */,
 				A346BD452D2E23FD002BA445 /* Then in Frameworks */,
 				A346BD4E2D2E2489002BA445 /* CombineCocoa in Frameworks */,
 				A346BD482D2E2449002BA445 /* Moya in Frameworks */,
+				A3128C052DE4A2B800DA4CA7 /* KakaoSDK in Frameworks */,
+				42D5EA59A4989AF59719BD17 /* libPods-Roomie.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -66,12 +75,21 @@
 			path = Pods;
 			sourceTree = "<group>";
 		};
+		983635455A99347013C271DE /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				2333A10B8CCAE5AB88BA7974 /* libPods-Roomie.a */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		A346BA382D2CDF13002BA445 = {
 			isa = PBXGroup;
 			children = (
 				A346BA432D2CDF13002BA445 /* Roomie */,
 				A346BA422D2CDF13002BA445 /* Products */,
 				9058F962AE18635590BD14B9 /* Pods */,
+				983635455A99347013C271DE /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -138,6 +156,7 @@
 				A346BD462D2E2449002BA445 /* XCRemoteSwiftPackageReference "Moya" */,
 				A346BD492D2E2477002BA445 /* XCRemoteSwiftPackageReference "Kingfisher" */,
 				A346BD4C2D2E2489002BA445 /* XCRemoteSwiftPackageReference "CombineCocoa" */,
+				A3128C032DE4A2B800DA4CA7 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = A346BA422D2CDF13002BA445 /* Products */;
@@ -429,6 +448,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		A3128C032DE4A2B800DA4CA7 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/kakao/kakao-ios-sdk";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.24.2;
+			};
+		};
 		A346BD402D2E23F0002BA445 /* XCRemoteSwiftPackageReference "SnapKit" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SnapKit/SnapKit";
@@ -472,6 +499,21 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		A3128C042DE4A2B800DA4CA7 /* KakaoSDK */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A3128C032DE4A2B800DA4CA7 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDK;
+		};
+		A3128C062DE4A2B800DA4CA7 /* KakaoSDKAuth */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A3128C032DE4A2B800DA4CA7 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDKAuth;
+		};
+		A3128C082DE4A2B800DA4CA7 /* KakaoSDKCommon */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A3128C032DE4A2B800DA4CA7 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDKCommon;
+		};
 		A346BD412D2E23F0002BA445 /* SnapKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = A346BD402D2E23F0002BA445 /* XCRemoteSwiftPackageReference "SnapKit" */;

--- a/Roomie/Roomie.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Roomie/Roomie.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -20,6 +20,15 @@
       }
     },
     {
+      "identity" : "kakao-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kakao/kakao-ios-sdk",
+      "state" : {
+        "revision" : "787763e335949dfad6b721aa04771e22d04e1493",
+        "version" : "2.24.2"
+      }
+    },
+    {
       "identity" : "kingfisher",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/onevcat/Kingfisher",

--- a/Roomie/Roomie/Application/AppDelegate.swift
+++ b/Roomie/Roomie/Application/AppDelegate.swift
@@ -7,22 +7,46 @@
 
 import UIKit
 
+import KakaoSDKAuth
+import KakaoSDKCommon
+
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
-
-
-
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
+    func application(
+        _ app: UIApplication,
+        open url: URL,
+        options: [UIApplication.OpenURLOptionsKey : Any] = [:]
+    ) -> Bool {
+        if (AuthApi.isKakaoTalkLoginUrl(url)) {
+            return AuthController.handleOpenUrl(url: url)
+        }
+        return false
+    }
+    
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+    ) -> Bool {
+        guard let key  = Bundle.main.infoDictionary?["KAKAO_NATIVE_APP_KEY"] as? String else {
+            fatalError("KAKAO_NATIVE_APP_KEY가 Info.plist에 없습니다.")
+        }
+        KakaoSDK.initSDK(appKey: key)
         return true
     }
-
+    
     // MARK: UISceneSession Lifecycle
 
-    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+    func application(
+        _ application: UIApplication,
+        configurationForConnecting connectingSceneSession: UISceneSession,
+        options: UIScene.ConnectionOptions
+    ) -> UISceneConfiguration {
         // Called when a new scene session is being created.
         // Use this method to select a configuration to create the new scene with.
-        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+        return UISceneConfiguration(
+            name: "Default Configuration",
+            sessionRole: connectingSceneSession.role
+        )
     }
 
     func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
@@ -30,7 +54,4 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
-
-
 }
-

--- a/Roomie/Roomie/Application/SceneDelegate.swift
+++ b/Roomie/Roomie/Application/SceneDelegate.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 
+import KakaoSDKAuth
+
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
     var window: UIWindow?
@@ -21,5 +23,13 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         self.window = UIWindow(windowScene: windowScene)
         self.window?.rootViewController = UINavigationController(rootViewController: onBoardingViewController)
         self.window?.makeKeyAndVisible()
+    }
+    
+    func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+        if let url = URLContexts.first?.url {
+            if (AuthApi.isKakaoTalkLoginUrl(url)) {
+                _ = AuthController.handleOpenUrl(url: url)
+            }
+        }
     }
 }

--- a/Roomie/Roomie/Global/Info.plist
+++ b/Roomie/Roomie/Global/Info.plist
@@ -2,13 +2,34 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>KAKAO_NATIVE_APP_KEY</key>
+	<string>$(KAKAO_NATIVE_APP_KEY)</string>
+	<key>BASE_URL</key>
+	<string>$(BASE_URL)</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>kakao$(KAKAO_NATIVE_APP_KEY)</string>
+			</array>
+		</dict>
+	</array>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>kakaokompassauth</string>
+		<string>kakaolink</string>
+		<string>kakaoplus</string>
+	</array>
+	<key>NMFClientId</key>
+	<string>$(NMFClientId)</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
-	<key>BASE_URL</key>
-	<string>$(BASE_URL)</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Pretendard-Bold.otf</string>
@@ -16,8 +37,6 @@
 		<string>Pretendard-Regular.otf</string>
 		<string>Pretendard-SemiBold.otf</string>
 	</array>
-	<key>NMFClientId</key>
-	<string>$(NMFClientId)</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/Roomie/Roomie/Network/DTO/Auth/AuthLoginRequestDTO.swift
+++ b/Roomie/Roomie/Network/DTO/Auth/AuthLoginRequestDTO.swift
@@ -1,0 +1,11 @@
+//
+//  AuthLogin.swift
+//  Roomie
+//
+//  Created by 예삐 on 5/27/25.
+//
+
+struct AuthLoginRequestDTO: RequestModelType {
+    let provider: String
+    let accessToken: String
+}

--- a/Roomie/Roomie/Network/DTO/Auth/AuthLoginResponseDTO.swift
+++ b/Roomie/Roomie/Network/DTO/Auth/AuthLoginResponseDTO.swift
@@ -1,0 +1,11 @@
+//
+//  AuthLoginResponseDTO.swift
+//  Roomie
+//
+//  Created by 예삐 on 5/27/25.
+//
+
+struct AuthLoginResponseDTO: ResponseModelType {
+    let accessToken: String
+    let refreshToken: String
+}

--- a/Roomie/Roomie/Network/Service/AuthService.swift
+++ b/Roomie/Roomie/Network/Service/AuthService.swift
@@ -1,0 +1,46 @@
+//
+//  AuthService.swift
+//  Roomie
+//
+//  Created by 예삐 on 5/27/25.
+//
+
+import Foundation
+
+import Moya
+
+final class AuthService {
+    let provider: MoyaProvider<AuthTargetType>
+    
+    init(provider: MoyaProvider<AuthTargetType> = MoyaProvider(plugins: [MoyaLoggingPlugin()])) {
+        self.provider = provider
+    }
+    
+    func request<T: ResponseModelType>(
+        with request: AuthTargetType
+    ) async throws -> BaseResponseBody<T>? {
+        return try await withCheckedThrowingContinuation {
+            continuation in provider.request(request) { result in
+                switch result {
+                case .success(let response):
+                    do {
+                        let decodedData = try JSONDecoder().decode(
+                            BaseResponseBody<T>.self, from: response.data
+                        )
+                        continuation.resume(returning: decodedData)
+                    } catch {
+                        continuation.resume(throwing: error)
+                    }
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+}
+
+extension AuthService: AuthServiceProtocol {
+    func authLogin(request: AuthLoginRequestDTO) async throws -> BaseResponseBody<AuthLoginResponseDTO>? {
+        return try await self.request(with: .authLogin(request: request))
+    }
+}

--- a/Roomie/Roomie/Network/TargetType/AuthTargetType.swift
+++ b/Roomie/Roomie/Network/TargetType/AuthTargetType.swift
@@ -1,0 +1,45 @@
+//
+//  AuthTargetType.swift
+//  Roomie
+//
+//  Created by 예삐 on 5/27/25.
+//
+
+import Foundation
+
+import Moya
+
+enum AuthTargetType {
+    case authLogin(request: AuthLoginRequestDTO)
+}
+
+extension AuthTargetType: TargetType {
+    var baseURL: URL {
+        return URL(string: "\(Environment.baseURL)/v1")!
+    }
+    
+    var path: String {
+        switch self {
+        case .authLogin:
+            return "/auth/oauth/login"
+        }
+    }
+    
+    var method: Moya.Method {
+        switch self {
+        case .authLogin:
+            return .post
+        }
+    }
+    
+    var task: Moya.Task {
+        switch self {
+        case .authLogin(let request):
+            return .requestJSONEncodable(request)
+        }
+    }
+    
+    var headers: [String : String]? {
+        return ["Content-Type": "application/json"]
+    }
+}

--- a/Roomie/Roomie/Presentation/OnBoarding/ServiceProtocol/AuthServiceProtocol.swift
+++ b/Roomie/Roomie/Presentation/OnBoarding/ServiceProtocol/AuthServiceProtocol.swift
@@ -1,0 +1,12 @@
+//
+//  AuthServiceProtocol.swift
+//  Roomie
+//
+//  Created by 예삐 on 5/27/25.
+//
+
+import Foundation
+
+protocol AuthServiceProtocol {
+    func authLogin(request: AuthLoginRequestDTO) async throws -> BaseResponseBody<AuthLoginResponseDTO>?
+}

--- a/Roomie/Roomie/Presentation/OnBoarding/ViewController/LoginViewController.swift
+++ b/Roomie/Roomie/Presentation/OnBoarding/ViewController/LoginViewController.swift
@@ -14,22 +14,64 @@ final class LoginViewController: BaseViewController {
     
     // MARK: - Property
     
+    private let rootView = LoginView()
+    
+    private let kakaoLoginButtonDidTap = PassthroughSubject<Void, Never>()
+    
+    private let viewModel: LoginViewModel
+    
     private let cancelBag = CancelBag()
     
-    // MARK: - UIComponent
+    // MARK: - Initializer
+
+    init(viewModel: LoginViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
     
-    private let rootView = LoginView()
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - LifeCycle
     
     override func loadView() {
         view = rootView
     }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        bindViewModel()
+    }
+    
+    // MARK: - Functions
     
     override func setAction() {
         rootView.kakaoLoginButton
             .tapPublisher
             .sink { [weak self] in
                 guard let self = self else { return }
-                self.navigationController?.pushViewController(MainTabBarController(), animated: true)
+                self.kakaoLoginButtonDidTap.send()
+            }
+            .store(in: cancelBag)
+    }
+}
+
+private extension LoginViewController {
+    func bindViewModel() {
+        let input = LoginViewModel.Input(
+            kakaoLoginButtonDidTapSubject: kakaoLoginButtonDidTap.eraseToAnyPublisher()
+        )
+        
+        let output = viewModel.transform(from: input, cancelBag: cancelBag)
+        
+        output.isLoginSucceedSubject
+            .sink { [weak self] isSucceed in
+                guard let self = self else { return }
+                if isSucceed {
+                    self.navigationController?.pushViewController(MainTabBarController(), animated: true)
+                }
             }
             .store(in: cancelBag)
     }

--- a/Roomie/Roomie/Presentation/OnBoarding/ViewController/LoginViewController.swift
+++ b/Roomie/Roomie/Presentation/OnBoarding/ViewController/LoginViewController.swift
@@ -67,6 +67,7 @@ private extension LoginViewController {
         let output = viewModel.transform(from: input, cancelBag: cancelBag)
         
         output.isLoginSucceedSubject
+            .receive(on: RunLoop.main)
             .sink { [weak self] isSucceed in
                 guard let self = self else { return }
                 if isSucceed {

--- a/Roomie/Roomie/Presentation/OnBoarding/ViewController/OnBoardingViewController.swift
+++ b/Roomie/Roomie/Presentation/OnBoarding/ViewController/OnBoardingViewController.swift
@@ -74,7 +74,9 @@ final class OnBoardingViewController: BaseViewController {
             .tapPublisher
             .sink { [weak self] in
                 guard let self = self else { return }
-                let navigationViewController = LoginViewController()
+                let navigationViewController = LoginViewController(
+                    viewModel: LoginViewModel(service: AuthService())
+                )
                 self.navigationController?.pushViewController(navigationViewController, animated: true)
             }
             .store(in: cancelBag)

--- a/Roomie/Roomie/Presentation/OnBoarding/ViewModel/LoginViewModel.swift
+++ b/Roomie/Roomie/Presentation/OnBoarding/ViewModel/LoginViewModel.swift
@@ -52,8 +52,10 @@ extension LoginViewModel: ViewModelType {
             }
             .store(in: cancelBag)
         
+        let isLoginSucceed = isLoginSucceedSubject.eraseToAnyPublisher()
+        
         return Output(
-            isLoginSucceedSubject: isLoginSucceedSubject.eraseToAnyPublisher()
+            isLoginSucceedSubject: isLoginSucceed
         )
     }
 }
@@ -64,6 +66,7 @@ private extension LoginViewModel {
             do {
                 guard let responseBody = try await service.authLogin(request: request),
                       let data = responseBody.data else { return }
+                isLoginSucceedSubject.send(true)
             } catch {
                 print(">>> \(error.localizedDescription) : \(#function)")
             }

--- a/Roomie/Roomie/Presentation/OnBoarding/ViewModel/LoginViewModel.swift
+++ b/Roomie/Roomie/Presentation/OnBoarding/ViewModel/LoginViewModel.swift
@@ -1,0 +1,72 @@
+//
+//  LoginViewModel.swift
+//  Roomie
+//
+//  Created by 예삐 on 5/27/25.
+//
+
+import Foundation
+import Combine
+
+import KakaoSDKUser
+
+final class LoginViewModel {
+    private let service: AuthServiceProtocol
+    
+    private let isLoginSucceedSubject = PassthroughSubject<Bool, Never>()
+    
+    init(service: AuthServiceProtocol) {
+        self.service = service
+    }
+}
+
+extension LoginViewModel: ViewModelType {
+    struct Input {
+        let kakaoLoginButtonDidTapSubject: AnyPublisher<Void, Never>
+    }
+    
+    struct Output {
+        let isLoginSucceedSubject: AnyPublisher<Bool, Never>
+    }
+    
+    func transform(from input: Input, cancelBag: CancelBag) -> Output {
+        input.kakaoLoginButtonDidTapSubject
+            .sink { [weak self] in
+                guard let self = self else { return }
+                if (UserApi.isKakaoTalkLoginAvailable()) {
+                    UserApi.shared.loginWithKakaoTalk {(oauthToken, error) in
+                        if let error = error {
+                            print(">>> \(error.localizedDescription) : \(#function)")
+                        }
+                        else {
+                            guard let oauthToken = oauthToken else { return }
+                            self.authLogin(
+                                request: AuthLoginRequestDTO(
+                                    provider: "KAKAO",
+                                    accessToken: oauthToken.accessToken
+                                )
+                            )
+                        }
+                    }
+                }
+            }
+            .store(in: cancelBag)
+        
+        return Output(
+            isLoginSucceedSubject: isLoginSucceedSubject.eraseToAnyPublisher()
+        )
+    }
+}
+
+private extension LoginViewModel {
+    func authLogin(request: AuthLoginRequestDTO) {
+        Task {
+            do {
+                guard let responseBody = try await service.authLogin(request: request),
+                      let data = responseBody.data else { return }
+            } catch {
+                print(">>> \(error.localizedDescription) : \(#function)")
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #160

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 카카오 로그인을 위한 세팅을 진행했어요
- 카카오 로그인 구현을 위한 일부 서버통신 세팅을 진행했어요 (AuthTargetType, AuthService, AuthServiceProtocol)
- 카카오 로그인을 구현했습니다! 카카오 로그인 버튼을 눌렀을 때 카카오로 부터 받은 AccessToken을 RequestBody에 담아 서버에 POST합니다. 서버 통신에 성공할 경우 홈 화면으로 이동합니다. (+ 이후 키체인을 통해 액세스토큰을 관리하는 작업이 필요해요. 때문에 현재는 서버 통신으로부터 받은 액세스토큰과 리프레쉬토큰을 사용하지 않습니다.)

|    구현 내용    |   iPhone 13 mini   |
| :-------------: | :----------: |
| 카카오 로그인 | <img src = "https://github.com/user-attachments/assets/dcec6d6f-aee3-4f5c-8b46-9a06985ccf4d" width ="250"> | 

## 📚 참고자료
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
- https://velog.io/@mandos1995/iOS-카카오-로그인-구현하기
- 카카오 로그인에 대한 자세한 구현 방식은 해당 블로그를 참고 부탁드립니다! (이해 안 되는 것이 있다면 질문 주시긔)

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
카카오 로그인 네이티브 앱 키가 추가되었으니, 카톡으로 공유드린 config 파일 꼭 다운로드 후 재적용 부탁합니다!