### PR TITLE
[feat/#166] 애플 소셜 로그인 구현

### DIFF
--- a/Roomie/Roomie.xcodeproj/project.pbxproj
+++ b/Roomie/Roomie.xcodeproj/project.pbxproj
@@ -241,6 +241,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = Roomie/Roomie.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
@@ -274,6 +275,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = Roomie/Roomie.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;

--- a/Roomie/Roomie/Presentation/OnBoarding/ViewController/LoginViewController.swift
+++ b/Roomie/Roomie/Presentation/OnBoarding/ViewController/LoginViewController.swift
@@ -10,6 +10,8 @@ import UIKit
 import SnapKit
 import Combine
 
+import AuthenticationServices
+
 final class LoginViewController: BaseViewController {
     
     // MARK: - Property
@@ -32,5 +34,70 @@ final class LoginViewController: BaseViewController {
                 self.navigationController?.pushViewController(MainTabBarController(), animated: true)
             }
             .store(in: cancelBag)
+        
+        rootView.appleLoginButton
+            .tapPublisher
+            .sink { [weak self] in
+                guard let self else { return }
+                self.appleLoginButtonDidTap()
+            }
+            .store(in: cancelBag)
+    }
+}
+
+extension LoginViewController {
+    func appleLoginButtonDidTap() {
+        print("애플 로그인 시작")
+        
+        let appleIDProvider = ASAuthorizationAppleIDProvider()
+        let request = appleIDProvider.createRequest()
+        request.requestedScopes = []
+        
+        let authorizationController = ASAuthorizationController(authorizationRequests: [request])
+        authorizationController.delegate = self
+        authorizationController.presentationContextProvider = self
+        authorizationController.performRequests()
+    }
+}
+
+extension LoginViewController: ASAuthorizationControllerPresentationContextProviding {
+    func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+        return self.view.window!
+    }
+}
+
+extension LoginViewController: ASAuthorizationControllerDelegate {
+    func authorizationController(
+        controller: ASAuthorizationController,
+        didCompleteWithAuthorization authorization: ASAuthorization
+    ) {
+        guard let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential else {
+            return
+        }
+        
+        let identityToken = appleIDCredential.identityToken.flatMap {
+            String(data: $0, encoding: .utf8)
+        }
+        
+        print("✅ Apple 로그인 성공!!!")
+        print("IdentityToken: \(String(describing: identityToken))")
+        
+        /*
+         Todo: Keychain에 애플 로그인 정보 저장
+         */
+
+        /*
+         Todo: 서버 통신 메서드 호출
+         */
+    }
+    
+    func authorizationController(
+        controller: ASAuthorizationController,
+        didCompleteWithError error: Error
+    ) {
+        /*
+         Todo: 에러 핸들링 (ex. alert창)
+         */
+        print("🚨Apple 로그인 실패: \(error.localizedDescription)")
     }
 }

--- a/Roomie/Roomie/Presentation/OnBoarding/ViewModel/LoginViewModel.swift
+++ b/Roomie/Roomie/Presentation/OnBoarding/ViewModel/LoginViewModel.swift
@@ -23,6 +23,7 @@ final class LoginViewModel {
 extension LoginViewModel: ViewModelType {
     struct Input {
         let kakaoLoginButtonDidTapSubject: AnyPublisher<Void, Never>
+        let appleLoginResultSubject: AnyPublisher<String, Never>
     }
     
     struct Output {
@@ -48,6 +49,19 @@ extension LoginViewModel: ViewModelType {
                         }
                     }
                 }
+            }
+            .store(in: cancelBag)
+        
+        input.appleLoginResultSubject
+            .sink { [weak self] identityToken in
+                guard let self else { return }
+                print("identityToken: \(identityToken)")
+                self.authLogin(
+                    request: AuthLoginRequestDTO(
+                        provider: "APPLE",
+                        accessToken: identityToken
+                    )
+                )
             }
             .store(in: cancelBag)
         

--- a/Roomie/Roomie/Roomie.entitlements
+++ b/Roomie/Roomie/Roomie.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>

--- a/Roomie/Roomie/RoomieRelease.entitlements
+++ b/Roomie/Roomie/RoomieRelease.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array/>
+</dict>
+</plist>


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #166 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 애플 로그인을 구현했어요

|    구현 내용    |   iPhone 13 pro   |
| :-------------: | :----------: |
| 애플 로그인 | <img src = "https://github.com/user-attachments/assets/0198720a-4ad0-4ab7-a756-1a4506245d3b" width ="250"> |

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### Apple 로그인이에요~

Apple의 인증 프레임워크인 `AuthenticationServices`를 사용하여 **사용자 인증 플로우를 트리거**합니다.

```swift
func performAppleLogin() {
    print("애플 로그인 시작")
    
    let appleIDProvider = ASAuthorizationAppleIDProvider()
    let request = appleIDProvider.createRequest()
    request.requestedScopes = [.fullName, .email] // 사용자에게 제공받을 정보 선택 (이름 & 이메일)
    
    let authorizationController = ASAuthorizationController(authorizationRequests: [request])
    authorizationController.delegate = self // 로그인 정보 관련 대리자 설정
    authorizationController.presentationContextProvider = self // 인증창 보여주기 위해 대리자 설정
    authorizationController.performRequests() // 요청
}
```

- 애플 로그인 버튼을 누르면, **viewModel**에 `send` 하지 않고, `LoginViewController`에 정의된 `performAppleLogin()` 함수를 호출합니다
- 그 이유는 `UIViewController`에서 대리자를 설정해 처리해줘야하기 때문에, 로그인 로직은 모두 **ViewController**에서 처리합니당

```Swift
// MARK: - ASAuthorizationControllerPresentationContextProviding

extension LoginViewController: ASAuthorizationControllerPresentationContextProviding {
    func presentationAnchor(
        for controller: ASAuthorizationController
    ) -> ASPresentationAnchor {
        return self.view.window!
    }
}
```
- 이 `ASAuthorizationControllerPresentationContextProviding`프로토콜 채택하여 위 함수를 구현합니다
- 여기서 강제 옵셔널 바인딩 해준 이유는 앱이 정상적으로 표시 중일 때는 `self.view.window`는 항상 유효한 **UIWindow**이기 때문입니다

```Swift
// MARK: - ASAuthorizationControllerDelegate

extension LoginViewController: ASAuthorizationControllerDelegate {
    // 사용자가 Apple ID 또는 iCloud Keychain을 통해 로그인 인증을 완료했을 때 호출되는 메서드
    func authorizationController(
        controller: ASAuthorizationController,
        didCompleteWithAuthorization authorization: ASAuthorization
    ) {
        guard let appleIDCredential = authorization.credential
                as? ASAuthorizationAppleIDCredential else { return }
        
        let identityToken = appleIDCredential.identityToken.flatMap {
            String(data: $0, encoding: .utf8)
        }
        
        if let identityToken {
            appleLoginResultSubject.send(identityToken) // <- token값 send()
        }
    }
    
    // 사용자가 Apple 로그인을 실패했을 때 호출되는 메서드
    func authorizationController(
        controller: ASAuthorizationController,
        didCompleteWithError error: Error
    ) {
        print("🚨Apple 로그인 실패: \(error.localizedDescription)")
    }
}
```
- `ASAuthorizationControllerDelegate`프로토콜을 채택하여 로그인 성공했을 때, 실패했을 때 호출되는 함수를 구현합니다
- 성공하면 **viewModel**에 **input**으로 **token**값을 `send()`합니다
- **viewModel**에서는 로그인API요청!!

## 📚 참고자료
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->

[Apple 로그인 공식 문서](https://developer.apple.com/documentation/authenticationservices/implementing-user-authentication-with-sign-in-with-apple) <- 정말 친절하게 하나하나 다 알려줌

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->

- @mmaybei 그 최근에 작성한 코드 중에 subject이름이 ~~ButtonDidTap으로 되어있는 게 있던데
- 예전 코드 보니까 ~~ButtonTapSubject 이렇게 이름을 통일했더라고 이것도 수정하면 좋을 거 같은데, 어떤가요
(코리할 때는 까먹고 있엇삼..ㅎㅎ)
