### PR TITLE
[feat/#168] 필터 뷰 스프린트 변경사항 반영

### DIFF
--- a/Roomie/Roomie/Network/DTO/Maps/MapRequestDTO.swift
+++ b/Roomie/Roomie/Network/DTO/Maps/MapRequestDTO.swift
@@ -9,12 +9,13 @@ import Foundation
 
 struct MapRequestDTO: RequestModelType {
     let location: String
-    let moodTag: String?
+    let moodTag: [String]
     let depositRange, monthlyRentRange: MinMaxRange
     let genderPolicy: [String]
     let preferredDate: String?
     let occupancyTypes: [String]
     let contractPeriod: [Int]
+    let excludeFull: Bool
 }
 
 struct MinMaxRange: Codable {

--- a/Roomie/Roomie/Network/DTO/Maps/MapRequestDTO.swift
+++ b/Roomie/Roomie/Network/DTO/Maps/MapRequestDTO.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct MapRequestDTO: RequestModelType {
-    let location: String
+    let location: String?
     let moodTag: [String]
     let depositRange, monthlyRentRange: MinMaxRange
     let genderPolicy: [String]

--- a/Roomie/Roomie/Network/DTO/Maps/MapResponseDTO.swift
+++ b/Roomie/Roomie/Network/DTO/Maps/MapResponseDTO.swift
@@ -13,7 +13,7 @@ struct MapResponseDTO: ResponseModelType {
 
 struct House: Codable, Hashable {
     let houseID: Int
-    let x, y: Double
+    let latitude, longitude: Double
     let monthlyRent, deposit: String
     let occupancyTypes: String
     let location, genderPolicy, locationDescription: String
@@ -24,7 +24,7 @@ struct House: Codable, Hashable {
     
     enum CodingKeys: String, CodingKey {
         case houseID = "houseId"
-        case x, y, monthlyRent, deposit, occupancyTypes, location, genderPolicy, locationDescription, isPinned, moodTag, contractTerm
+        case latitude, longitude, monthlyRent, deposit, occupancyTypes, location, genderPolicy, locationDescription, isPinned, moodTag, contractTerm
         case mainImageURL = "mainImgUrl"
     }
 }

--- a/Roomie/Roomie/Network/Service/MapsService.swift
+++ b/Roomie/Roomie/Network/Service/MapsService.swift
@@ -106,8 +106,8 @@ final class MockMapSearchService: MapSearchServiceProtocol {
             houses: [
                 House(
                     houseID: 1,
-                    x: 37.555184166,
-                    y: 126.936910322,
+                    latitude: 37.555184166,
+                    longitude: 126.936910322,
                     monthlyRent: "35~50",
                     deposit: "200~300",
                     occupancyTypes: "2인실",
@@ -121,8 +121,8 @@ final class MockMapSearchService: MapSearchServiceProtocol {
                 ),
                 House(
                     houseID: 2,
-                    x: 37.552502661,
-                    y: 126.934998613,
+                    latitude: 37.552502661,
+                    longitude: 126.934998613,
                     monthlyRent: "25~40",
                     deposit: "50~100",
                     occupancyTypes: "4인실",
@@ -136,8 +136,8 @@ final class MockMapSearchService: MapSearchServiceProtocol {
                 ),
                 House(
                     houseID: 3,
-                    x: 37.553909,
-                    y: 126.933960,
+                    latitude: 37.553909,
+                    longitude: 126.933960,
                     monthlyRent: "50~80",
                     deposit: "300~500",
                     occupancyTypes: "1인실",
@@ -151,8 +151,8 @@ final class MockMapSearchService: MapSearchServiceProtocol {
                 ),
                 House(
                     houseID: 4,
-                    x: 37.556304,
-                    y: 126.943263,
+                    latitude: 37.556304,
+                    longitude: 126.943263,
                     monthlyRent: "30~50",
                     deposit: "100~300",
                     occupancyTypes: "2인실",
@@ -166,8 +166,8 @@ final class MockMapSearchService: MapSearchServiceProtocol {
                 ),
                 House(
                     houseID: 5,
-                    x: 37.547670,
-                    y: 126.942370,
+                    latitude: 37.547670,
+                    longitude: 126.942370,
                     monthlyRent: "50~70",
                     deposit: "50~100",
                     occupancyTypes: "3인실",

--- a/Roomie/Roomie/Presentation/Map/ViewModel/MapViewModel.swift
+++ b/Roomie/Roomie/Presentation/Map/ViewModel/MapViewModel.swift
@@ -77,7 +77,7 @@ extension MapViewModel: ViewModelType {
         
         let markersInfo = mapDataSubject
             .compactMap { data in
-                data?.houses.map { MarkerInfo(houseID: $0.houseID, x: $0.x, y: $0.y) }
+                data?.houses.map { MarkerInfo(houseID: $0.houseID, x: $0.latitude, y: $0.longitude) }
             }
             .eraseToAnyPublisher()
         

--- a/Roomie/Roomie/Presentation/MapFilter/Model/MapRequestModelBuilder.swift
+++ b/Roomie/Roomie/Presentation/MapFilter/Model/MapRequestModelBuilder.swift
@@ -12,13 +12,14 @@ extension MapRequestDTO {
         static let shared = MapRequestDTO.Builder()
         
         private var location: String = "서울특별시 마포구 노고산동"
-        private var moodTag: String? = nil
+        private var moodTag: [String] = []
         private var depositRange: MinMaxRange = MinMaxRange(min: 0, max: 500)
         private var monthlyRentRange: MinMaxRange = MinMaxRange(min: 0, max: 150)
         private var genderPolicy: [String] = []
         private var preferredDate: String? = nil
         private var occupancyTypes: [String] = []
         private var contractPeroid: [Int] = []
+        private var excludeFull: Bool = false
         
         @discardableResult
         func setLocation(_ location: String) -> Self {
@@ -27,7 +28,7 @@ extension MapRequestDTO {
         }
         
         @discardableResult
-        func setMoodTag(_ moodTag: String?) -> Self {
+        func setMoodTag(_ moodTag: [String]) -> Self {
             self.moodTag = moodTag
             return self
         }
@@ -77,7 +78,8 @@ extension MapRequestDTO {
                 genderPolicy: genderPolicy,
                 preferredDate: preferredDate,
                 occupancyTypes: occupancyTypes,
-                contractPeriod: contractPeroid
+                contractPeriod: contractPeroid,
+                excludeFull: excludeFull
             )
         }
     }

--- a/Roomie/Roomie/Presentation/MapFilter/Model/MapRequestModelBuilder.swift
+++ b/Roomie/Roomie/Presentation/MapFilter/Model/MapRequestModelBuilder.swift
@@ -22,7 +22,7 @@ extension MapRequestDTO {
         private var excludeFull: Bool = false
         
         @discardableResult
-        func setLocation(_ location: String) -> Self {
+        func setLocation(_ location: String?) -> Self {
             self.location = location
             return self
         }

--- a/Roomie/Roomie/Presentation/MapFilter/Model/MapRequestModelBuilder.swift
+++ b/Roomie/Roomie/Presentation/MapFilter/Model/MapRequestModelBuilder.swift
@@ -11,7 +11,7 @@ extension MapRequestDTO {
     final class Builder {
         static let shared = MapRequestDTO.Builder()
         
-        private var location: String = "서울특별시 마포구 노고산동"
+        private var location: String? = nil
         private var moodTag: [String] = []
         private var depositRange: MinMaxRange = MinMaxRange(min: 0, max: 500)
         private var monthlyRentRange: MinMaxRange = MinMaxRange(min: 0, max: 150)

--- a/Roomie/Roomie/Presentation/MapFilter/View/FilterRoomView.swift
+++ b/Roomie/Roomie/Presentation/MapFilter/View/FilterRoomView.swift
@@ -18,21 +18,28 @@ final class FilterRoomView: BaseView {
     let genderDivisionButton = FilterOptionButton(title: "남녀분리")
     let genderFreeButton = FilterOptionButton(title: "성별무관")
     
-    private let occupancyTypeLabl = UILabel()
+    private let occupancyTypeLabel = UILabel()
     let singleButton = FilterOptionButton(title: "1인실")
     let doubleButton = FilterOptionButton(title: "2인실")
     let tripleButton = FilterOptionButton(title: "3인실")
-    let quadButton = FilterOptionButton(title: "4인실")
-    let quintButton = FilterOptionButton(title: "5인실")
-    let sextButton = FilterOptionButton(title: "6인실")
+    let quadButton = FilterOptionButton(title: "4인실 이상")
+    
+    private let moodTagLabel = UILabel()
+    let calmButton = FilterOptionButton(title: "차분한")
+    let livelyButton = FilterOptionButton(title: "활기찬")
+    let neatButton = FilterOptionButton(title: "깔끔한")
     
     override func setStyle() {
         genderLabel.do {
             $0.setText("성별", style: .body2, color: .grayscale12)
         }
         
-        occupancyTypeLabl.do {
+        occupancyTypeLabel.do {
             $0.setText("룸 타입", style: .body2, color: .grayscale12)
+        }
+        
+        moodTagLabel.do {
+            $0.setText("분위기", style: .body2, color: .grayscale12)
         }
     }
     
@@ -43,13 +50,15 @@ final class FilterRoomView: BaseView {
             femaleButton,
             genderDivisionButton,
             genderFreeButton,
-            occupancyTypeLabl,
+            occupancyTypeLabel,
             singleButton,
             doubleButton,
             tripleButton,
             quadButton,
-            quintButton,
-            sextButton
+            moodTagLabel,
+            calmButton,
+            livelyButton,
+            neatButton
         )
     }
     
@@ -79,39 +88,49 @@ final class FilterRoomView: BaseView {
             $0.leading.equalTo(genderDivisionButton.snp.trailing).offset(8)
         }
         
-        occupancyTypeLabl.snp.makeConstraints {
+        occupancyTypeLabel.snp.makeConstraints {
             $0.top.equalTo(maleButton.snp.bottom).offset(48)
             $0.leading.equalToSuperview().inset(20)
         }
         
         singleButton.snp.makeConstraints {
-            $0.top.equalTo(occupancyTypeLabl.snp.bottom).offset(12)
+            $0.top.equalTo(occupancyTypeLabel.snp.bottom).offset(12)
             $0.leading.equalToSuperview().inset(20)
         }
         
         doubleButton.snp.makeConstraints {
-            $0.top.equalTo(occupancyTypeLabl.snp.bottom).offset(12)
+            $0.top.equalTo(occupancyTypeLabel.snp.bottom).offset(12)
             $0.leading.equalTo(singleButton.snp.trailing).offset(8)
         }
         
         tripleButton.snp.makeConstraints {
-            $0.top.equalTo(occupancyTypeLabl.snp.bottom).offset(12)
+            $0.top.equalTo(occupancyTypeLabel.snp.bottom).offset(12)
             $0.leading.equalTo(doubleButton.snp.trailing).offset(8)
         }
         
         quadButton.snp.makeConstraints {
-            $0.top.equalTo(occupancyTypeLabl.snp.bottom).offset(12)
+            $0.top.equalTo(occupancyTypeLabel.snp.bottom).offset(12)
             $0.leading.equalTo(tripleButton.snp.trailing).offset(8)
         }
         
-        quintButton.snp.makeConstraints {
-            $0.top.equalTo(singleButton.snp.bottom).offset(8)
+        moodTagLabel.snp.makeConstraints {
+            $0.top.equalTo(singleButton.snp.bottom).offset(48)
             $0.leading.equalToSuperview().inset(20)
         }
         
-        sextButton.snp.makeConstraints {
-            $0.top.equalTo(singleButton.snp.bottom).offset(8)
-            $0.leading.equalTo(quintButton.snp.trailing).offset(8)
+        calmButton.snp.makeConstraints {
+            $0.top.equalTo(moodTagLabel.snp.bottom).offset(12)
+            $0.leading.equalToSuperview().inset(20)
+        }
+        
+        livelyButton.snp.makeConstraints {
+            $0.top.equalTo(moodTagLabel.snp.bottom).offset(12)
+            $0.leading.equalTo(calmButton.snp.trailing).offset(8)
+        }
+        
+        neatButton.snp.makeConstraints {
+            $0.top.equalTo(moodTagLabel.snp.bottom).offset(12)
+            $0.leading.equalTo(livelyButton.snp.trailing).offset(8)
         }
     }
 }

--- a/Roomie/Roomie/Presentation/MapFilter/ViewController/MapFilterViewController.swift
+++ b/Roomie/Roomie/Presentation/MapFilter/ViewController/MapFilterViewController.swift
@@ -37,8 +37,10 @@ final class MapFilterViewController: BaseViewController {
     private let doubleButtonDidTapSubject = PassthroughSubject<Void, Never>()
     private let tripleButtonDidTapSubject = PassthroughSubject<Void, Never>()
     private let quadButtonDidTapSubject = PassthroughSubject<Void, Never>()
-    private let quintButtonDidTapSubject = PassthroughSubject<Void, Never>()
-    private let sextButtonDidTapSubject = PassthroughSubject<Void, Never>()
+    
+    private let calmButtonDidTapSubject = PassthroughSubject<Void, Never>()
+    private let livelyButtonDidTapSubject = PassthroughSubject<Void, Never>()
+    private let neatButtonDidTapSubject = PassthroughSubject<Void, Never>()
     
     private let preferredDateSubject = PassthroughSubject<String?, Never>()
     
@@ -201,19 +203,27 @@ final class MapFilterViewController: BaseViewController {
             }
             .store(in: cancelBag)
         
-        rootView.filterRoomView.quintButton.optionButton
+        rootView.filterRoomView.calmButton.optionButton
             .tapPublisher
             .sink { [weak self] in
                 guard let self = self else { return }
-                self.quintButtonDidTapSubject.send(())
+                self.calmButtonDidTapSubject.send(())
             }
             .store(in: cancelBag)
         
-        rootView.filterRoomView.sextButton.optionButton
+        rootView.filterRoomView.livelyButton.optionButton
             .tapPublisher
             .sink { [weak self] in
                 guard let self = self else { return }
-                self.sextButtonDidTapSubject.send(())
+                self.livelyButtonDidTapSubject.send(())
+            }
+            .store(in: cancelBag)
+        
+        rootView.filterRoomView.neatButton.optionButton
+            .tapPublisher
+            .sink { [weak self] in
+                guard let self = self else { return }
+                self.neatButtonDidTapSubject.send(())
             }
             .store(in: cancelBag)
         
@@ -286,8 +296,9 @@ private extension MapFilterViewController {
             doubleButtonDidTap: doubleButtonDidTapSubject.eraseToAnyPublisher(),
             tripleButtonDidTap: tripleButtonDidTapSubject.eraseToAnyPublisher(),
             quadButtonDidTap: quadButtonDidTapSubject.eraseToAnyPublisher(),
-            quintButtonDidTap: quintButtonDidTapSubject.eraseToAnyPublisher(),
-            sextButtonDidTap: sextButtonDidTapSubject.eraseToAnyPublisher(),
+            calmButtonDidTap: calmButtonDidTapSubject.eraseToAnyPublisher(),
+            livelyButtonDidTap: livelyButtonDidTapSubject.eraseToAnyPublisher(),
+            neatButtonDidTap: neatButtonDidTapSubject.eraseToAnyPublisher(),
             preferredDate: preferredDateSubject.eraseToAnyPublisher(),
             threeMonthButtonDidTap: threeMonthButtonDidTapSubject.eraseToAnyPublisher(),
             sixMonthButtonDidTap: sixMonthButtonDidTapSubject.eraseToAnyPublisher(),
@@ -355,9 +366,23 @@ private extension MapFilterViewController {
                     self.rootView.filterRoomView.singleButton,
                     self.rootView.filterRoomView.doubleButton,
                     self.rootView.filterRoomView.tripleButton,
-                    self.rootView.filterRoomView.quadButton,
-                    self.rootView.filterRoomView.quintButton,
-                    self.rootView.filterRoomView.sextButton
+                    self.rootView.filterRoomView.quadButton
+                ]
+                
+                if isEmpty {
+                    buttons.forEach { $0.isSelected = false }
+                }
+            }
+            .store(in: cancelBag)
+        
+        output.isMoodTagEmpty
+            .sink { [weak self] isEmpty in
+                guard let self = self else { return }
+                
+                let buttons = [
+                    self.rootView.filterRoomView.calmButton,
+                    self.rootView.filterRoomView.livelyButton,
+                    self.rootView.filterRoomView.neatButton
                 ]
                 
                 if isEmpty {

--- a/Roomie/Roomie/Presentation/MapFilter/ViewModel/MapFilterViewModel.swift
+++ b/Roomie/Roomie/Presentation/MapFilter/ViewModel/MapFilterViewModel.swift
@@ -22,6 +22,7 @@ final class MapFilterViewModel {
     
     private let genderSubject = CurrentValueSubject<[String], Never>([])
     private let occupancyTypeSubject = CurrentValueSubject<[String], Never>([])
+    private let moodTagSubject = CurrentValueSubject<[String], Never>([])
     
     private let preferredDateSubject = CurrentValueSubject<String?, Never>(nil)
     private let contractPeriodSubject = CurrentValueSubject<[Int], Never>([])
@@ -52,8 +53,11 @@ extension MapFilterViewModel: ViewModelType {
         let doubleButtonDidTap: AnyPublisher<Void, Never>
         let tripleButtonDidTap: AnyPublisher<Void, Never>
         let quadButtonDidTap: AnyPublisher<Void, Never>
-        let quintButtonDidTap: AnyPublisher<Void, Never>
-        let sextButtonDidTap: AnyPublisher<Void, Never>
+        
+        /// 분위기 옵션
+        let calmButtonDidTap: AnyPublisher<Void, Never>
+        let livelyButtonDidTap: AnyPublisher<Void, Never>
+        let neatButtonDidTap: AnyPublisher<Void, Never>
         
         /// 계약기간 옵션
         let preferredDate: AnyPublisher<String?, Never>
@@ -78,6 +82,7 @@ extension MapFilterViewModel: ViewModelType {
         /// 방 형태
         let isGenderEmpty: AnyPublisher<Bool, Never>
         let isOccupancyTypeEmpty: AnyPublisher<Bool, Never>
+        let isMoodTagEmpty: AnyPublisher<Bool, Never>
         
         /// 계약기간
         let isPreferredDateEmpty: AnyPublisher<Bool, Never>
@@ -241,28 +246,41 @@ extension MapFilterViewModel: ViewModelType {
             }
             .store(in: cancelBag)
         
-        input.quintButtonDidTap
+        input.calmButtonDidTap
             .sink { [weak self] in
                 guard let self = self else { return }
-                let occupancyType = "5인실"
+                let moodTag = "#차분한"
                 
-                self.occupancyTypeSubject.send(
-                    self.occupancyTypeSubject.value.contains(occupancyType)
-                    ? self.occupancyTypeSubject.value.filter { $0 != occupancyType }
-                    : self.occupancyTypeSubject.value + [occupancyType]
+                self.moodTagSubject.send(
+                    self.moodTagSubject.value.contains(moodTag)
+                    ? self.moodTagSubject.value.filter { $0 != moodTag }
+                    : self.moodTagSubject.value + [moodTag]
                 )
             }
             .store(in: cancelBag)
         
-        input.sextButtonDidTap
+        input.livelyButtonDidTap
             .sink { [weak self] in
                 guard let self = self else { return }
-                let occupancyType = "6인실"
+                let moodTag = "#활기찬"
                 
-                self.occupancyTypeSubject.send(
-                    self.occupancyTypeSubject.value.contains(occupancyType)
-                    ? self.occupancyTypeSubject.value.filter { $0 != occupancyType }
-                    : self.occupancyTypeSubject.value + [occupancyType]
+                self.moodTagSubject.send(
+                    self.moodTagSubject.value.contains(moodTag)
+                    ? self.moodTagSubject.value.filter { $0 != moodTag }
+                    : self.moodTagSubject.value + [moodTag]
+                )
+            }
+            .store(in: cancelBag)
+        
+        input.neatButtonDidTap
+            .sink { [weak self] in
+                guard let self = self else { return }
+                let moodTag = "#깔끔한"
+                
+                self.moodTagSubject.send(
+                    self.moodTagSubject.value.contains(moodTag)
+                    ? self.moodTagSubject.value.filter { $0 != moodTag }
+                    : self.moodTagSubject.value + [moodTag]
                 )
             }
             .store(in: cancelBag)
@@ -324,6 +342,7 @@ extension MapFilterViewModel: ViewModelType {
                 self.monthlyRentMinSubject.send(0)
                 self.genderSubject.send([])
                 self.occupancyTypeSubject.send([])
+                self.moodTagSubject.send([])
                 self.preferredDateSubject.send("")
                 self.contractPeriodSubject.send([])
             }
@@ -348,6 +367,7 @@ extension MapFilterViewModel: ViewModelType {
                     )
                     .setGenderPolicy(genderSubject.value)
                     .setOccupancyTypes(occupancyTypeSubject.value)
+                    .setMoodTag(moodTagSubject.value)
                     .setPreferredDate(preferredDateSubject.value)
                     .setContractPeroid(contractPeriodSubject.value)
             }
@@ -373,6 +393,10 @@ extension MapFilterViewModel: ViewModelType {
             .map { $0.isEmpty }
             .eraseToAnyPublisher()
         
+        let isMoodTagEmpty = moodTagSubject
+            .map { $0.isEmpty }
+            .eraseToAnyPublisher()
+        
         let isPreferredEmpty = preferredDateSubject
             .map { $0?.isEmpty ?? true }
             .eraseToAnyPublisher()
@@ -388,6 +412,7 @@ extension MapFilterViewModel: ViewModelType {
             monthlyRentMaxText: monthlyRentMax,
             isGenderEmpty: isGenderEmpty,
             isOccupancyTypeEmpty: isOccupancyTypeEmpty,
+            isMoodTagEmpty: isMoodTagEmpty,
             isPreferredDateEmpty: isPreferredEmpty,
             isContractPeriodEmpty: isContractPeriodEmpty
         )


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #168 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 기존에 1인실, 2인실, ⋯ 6인실이던 방 형태를 1인실, 2인실, ⋯ 4인실 이상으로 수정했어요.
- 분위기 옵션을 새롭게 추가했어요.
- 비즈니스 로직, API 변경사항 등 모두 반영했습니다. 아직 API가 고쳐지지 않아서 실테스트는 해보지 못했지만 로그로 확인했고요, 그냥 저를 믿습니다. ㅋㅋ 이게안되는게말이안됨

|    구현 내용    |   iPhone 13 mini   |
| :-------------: | :----------: |
| 필터 뷰 | <img src = "https://github.com/user-attachments/assets/3fabe72d-8d48-45c1-8781-9bdf8c107dac" width ="250"> |

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
- 필터 뷰 뚱뚱한 비즈니스 로직들,, 중복되는 게 많아서 한번 손보고 싶은데 피쳐 다 쳐내고 나서 해보겠습니더
- 지금까지 occupancyTypeLabl라고 되어있었는데 아무도 몰랐음 ⋯ occupancyTypeLabel로 수정 완, ㅋㅋ 😂