### PR TITLE
[fix/#184] 관심지역 위치 설정 바텀시트 UI 수정

### DIFF
--- a/Roomie/Roomie/Presentation/Home/View/LocationSearchSheetView.swift
+++ b/Roomie/Roomie/Presentation/Home/View/LocationSearchSheetView.swift
@@ -73,7 +73,7 @@ final class LocationSearchSheetView: BaseView {
     
     override func setLayout() {
         locationSettingLabel.snp.makeConstraints{
-            $0.top.equalToSuperview().inset(14)
+            $0.top.equalToSuperview().inset(32)
             $0.leading.equalToSuperview().inset(16)
         }
         

--- a/Roomie/Roomie/Presentation/Home/View/LocationSearchSheetView.swift
+++ b/Roomie/Roomie/Presentation/Home/View/LocationSearchSheetView.swift
@@ -40,6 +40,7 @@ final class LocationSearchSheetView: BaseView {
         locationLabel.do {
             $0.setText(style: .body5, color: .grayscale10)
         }
+        
         searchImageView.do {
             $0.image = .icnSearch40
         }

--- a/Roomie/Roomie/Presentation/Home/View/LocationSearchSheetView.swift
+++ b/Roomie/Roomie/Presentation/Home/View/LocationSearchSheetView.swift
@@ -14,6 +14,8 @@ final class LocationSearchSheetView: BaseView {
     
     // MARK: - UIComponent
     
+    private let locationSettingLabel = UILabel()
+    let locationLabel = UILabel()
     let searchTextField = MapSearchTextField("원하는 장소를 찾아보세요")
     private let searchImageView = UIImageView()
     private let seperatorView = UIView()
@@ -31,6 +33,13 @@ final class LocationSearchSheetView: BaseView {
     // MARK: - UISetting
     
     override func setStyle() {
+        locationSettingLabel.do {
+            $0.setText("현재 설정된 위치:", style: .body5, color: .grayscale10)
+        }
+        
+        locationLabel.do {
+            $0.setText(style: .body5, color: .grayscale10)
+        }
         searchImageView.do {
             $0.image = .icnSearch40
         }
@@ -52,6 +61,8 @@ final class LocationSearchSheetView: BaseView {
     
     override func setUI() {
         addSubviews(
+            locationSettingLabel,
+            locationLabel,
             searchTextField,
             searchImageView,
             seperatorView,
@@ -61,8 +72,18 @@ final class LocationSearchSheetView: BaseView {
     }
     
     override func setLayout() {
+        locationSettingLabel.snp.makeConstraints{
+            $0.top.equalToSuperview().inset(14)
+            $0.leading.equalToSuperview().inset(16)
+        }
+        
+        locationLabel.snp.makeConstraints{
+            $0.top.equalTo(locationSettingLabel.snp.top)
+            $0.leading.equalTo(locationSettingLabel.snp.trailing).offset(4)
+        }
+        
         searchTextField.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(20)
+            $0.top.equalTo(locationSettingLabel.snp.bottom).offset(14)
             $0.horizontalEdges.equalToSuperview().inset(16)
             $0.height.equalTo(Screen.height(50))
         }

--- a/Roomie/Roomie/Presentation/Home/ViewController/HomeViewController.swift
+++ b/Roomie/Roomie/Presentation/Home/ViewController/HomeViewController.swift
@@ -37,6 +37,7 @@ final class HomeViewController: BaseViewController {
     final let cellHeight: CGFloat = 112
     final let cellWidth: CGFloat = UIScreen.main.bounds.width - 32
     final let contentInterSpacing: CGFloat = 4
+    final let bottomSheetHeight: CGFloat = UIScreen.main.bounds.height * 0.85
     
     private var homeNavigationBarStatus: homeNavigationBarStatus = .scrolled {
         didSet {
@@ -79,7 +80,6 @@ final class HomeViewController: BaseViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        setAction()
         updateSeletedCell()
         setHomeNavigationBarStatus()
         viewWillAppearSubject.send()
@@ -177,7 +177,6 @@ private extension HomeViewController {
                 guard let self else { return }
                 self.rootView.nameLabel.text = data.nickname
                 self.setHomeNavigationBar(locaton: data.location)
-                
             }
             .store(in: cancelBag)
         
@@ -338,14 +337,16 @@ private extension HomeViewController {
         let locationViewController = LocationSearchSheetViewController(
             viewModel: HomeViewModel(service: HomeService())
         )
+        
         locationViewController.delegate = self
+        
+        let customDetent = UISheetPresentationController.Detent.custom { _ in self.bottomSheetHeight }
+        
         if let sheet = locationViewController.sheetPresentationController {
-            sheet.detents = [.medium(), .large()]
+            sheet.detents = [customDetent]
             sheet.prefersGrabberVisible = true
             sheet.preferredCornerRadius = 20
         }
-        locationViewController.isModalInPresentation = false
-        locationViewController.isModalInPresentation = false
         
         self.present(locationViewController, animated: true)
     }

--- a/Roomie/Roomie/Presentation/Home/ViewController/HomeViewController.swift
+++ b/Roomie/Roomie/Presentation/Home/ViewController/HomeViewController.swift
@@ -79,6 +79,7 @@ final class HomeViewController: BaseViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
+        setAction()
         updateSeletedCell()
         setHomeNavigationBarStatus()
         viewWillAppearSubject.send()
@@ -339,11 +340,13 @@ private extension HomeViewController {
         )
         locationViewController.delegate = self
         if let sheet = locationViewController.sheetPresentationController {
-            sheet.detents = [.large()]
+            sheet.detents = [.medium(), .large()]
             sheet.prefersGrabberVisible = true
             sheet.preferredCornerRadius = 20
         }
         locationViewController.isModalInPresentation = false
+        locationViewController.isModalInPresentation = false
+        
         self.present(locationViewController, animated: true)
     }
     

--- a/Roomie/Roomie/Presentation/Home/ViewController/HomeViewController.swift
+++ b/Roomie/Roomie/Presentation/Home/ViewController/HomeViewController.swift
@@ -176,6 +176,7 @@ private extension HomeViewController {
                 guard let self else { return }
                 self.rootView.nameLabel.text = data.nickname
                 self.setHomeNavigationBar(locaton: data.location)
+                
             }
             .store(in: cancelBag)
         

--- a/Roomie/Roomie/Presentation/Home/ViewController/LocationSearchViewController.swift
+++ b/Roomie/Roomie/Presentation/Home/ViewController/LocationSearchViewController.swift
@@ -80,8 +80,6 @@ final class LocationSearchSheetViewController: BaseViewController {
     override func setAction() {
         hideKeyboardWhenDidTap()
         
-        rootView.searchTextField.becomeFirstResponder()
-        
         rootView.searchTextField
             .controlEventPublisher(for: .editingDidEndOnExit)
             .sink { [weak self] in


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #184 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 관심 지역 위치 설정 바텀시트 UI를 수정하였습니다.
- 바텀시트 높이 커스텀을 하기 위해서는 시트로 구현하는 것이 아니라 따로 뷰컨을 만들어서 커스텀 해줘야하더라구용..🥹 그래서 우선 medium, large로 높이를 구현하였습니다 !
- 바텀시트가 올라옴과 동시에 키보드가 올라오게 구현했던 것을 텍스트 필드 선택 시 키보드가 올라오도록 수정하였습니다!

|    구현 내용    |   iPhone 13 mini   |
| :-------------: | :----------: |
| 바텀시트 사이즈 조정 | <video src = "https://github.com/user-attachments/assets/b9dd57a6-f3bb-45c3-afbf-1f58a43838bb" width ="250"> | 
| 텍스트필드 키보드 | <video src = "https://github.com/user-attachments/assets/3113afb0-4ddb-488b-9fd9-10765e6b5737" width ="250"> | 

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
제 생각에는요.. 바텀시트 UI..? 지금도 충분히 아름다운 것 같습니다.