### PR TITLE
[refactor/#182] 소셜 타입 적용, Toast 수정

### DIFF
--- a/Roomie/Roomie/Application/SceneDelegate.swift
+++ b/Roomie/Roomie/Application/SceneDelegate.swift
@@ -84,8 +84,8 @@ private extension SceneDelegate {
             self.updateRootViewController()
             
             if fromManualLogin {
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                    Toast.show(message: "로그인에 성공했어요")
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {                    
+                    Toast.show(.loginSuccess)
                 }
             }
         }

--- a/Roomie/Roomie/Application/SceneDelegate.swift
+++ b/Roomie/Roomie/Application/SceneDelegate.swift
@@ -78,16 +78,8 @@ private extension SceneDelegate {
 
     @objc
     func handleLogin(_ notification: Notification) {
-        let fromManualLogin = notification.userInfo?["manualLogin"] as? Bool ?? false
-        
         DispatchQueue.main.async {
             self.updateRootViewController()
-            
-            if fromManualLogin {
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {                    
-                    Toast.show(.loginSuccess)
-                }
-            }
         }
     }
 }

--- a/Roomie/Roomie/Global/Enums/SocialType.swift
+++ b/Roomie/Roomie/Global/Enums/SocialType.swift
@@ -5,16 +5,7 @@
 //  Created by 예삐 on 6/5/25.
 //
 
-enum SocialType {
-    case kakao
-    case apple
-    
-    var socialTypeString: String {
-        switch self {
-        case .kakao:
-            return "KAKAO"
-        case .apple:
-            return "APPLE"
-        }
-    }
+enum SocialType: String {
+    case kakao = "KAKAO"
+    case apple = "APPLE"
 }

--- a/Roomie/Roomie/Global/Enums/ToastType.swift
+++ b/Roomie/Roomie/Global/Enums/ToastType.swift
@@ -1,0 +1,40 @@
+//
+//  ToastType.swift
+//  Roomie
+//
+//  Created by 김승원 on 6/12/25.
+//
+
+import Foundation
+
+enum ToastType {
+    case loginSuccess
+    case sessionExpired
+    case serverError
+    case requestFailed
+    case unexpectedError
+    
+    var message: String {
+        switch self {
+        case .loginSuccess:
+            return "로그인에 성공했어요"
+        case .sessionExpired:
+            return "세션이 만료되었어요. 다시 로그인해주세요"
+        case .serverError:
+            return "서버 오류입니다. 다시 시도해주세요"
+        case .requestFailed:
+            return "요청에 실패했습니다. 잠시 후 다시 시도해주세요"
+        case .unexpectedError:
+            return "예기치 못한 오류가 발생했어요"
+        }
+    }
+    
+    var bottomInset: CGFloat {
+        switch self {
+        case .sessionExpired:
+            return Screen.height(20)
+        case .loginSuccess, .serverError, .requestFailed, .unexpectedError:
+            return Screen.height(100)
+        }
+    }
+}

--- a/Roomie/Roomie/Global/Enums/ToastType.swift
+++ b/Roomie/Roomie/Global/Enums/ToastType.swift
@@ -8,18 +8,12 @@
 import Foundation
 
 enum ToastType {
-    case loginSuccess
-    case sessionExpired
     case serverError
     case requestFailed
     case unexpectedError
     
     var message: String {
         switch self {
-        case .loginSuccess:
-            return "로그인에 성공했어요"
-        case .sessionExpired:
-            return "세션이 만료되었어요. 다시 로그인해주세요"
         case .serverError:
             return "서버 오류입니다. 다시 시도해주세요"
         case .requestFailed:
@@ -31,9 +25,7 @@ enum ToastType {
     
     var bottomInset: CGFloat {
         switch self {
-        case .sessionExpired:
-            return Screen.height(20)
-        case .loginSuccess, .serverError, .requestFailed, .unexpectedError:
+        case .serverError, .requestFailed, .unexpectedError:
             return Screen.height(100)
         }
     }

--- a/Roomie/Roomie/Global/Enums/ToastType.swift
+++ b/Roomie/Roomie/Global/Enums/ToastType.swift
@@ -24,9 +24,6 @@ enum ToastType {
     }
     
     var bottomInset: CGFloat {
-        switch self {
-        case .serverError, .requestFailed, .unexpectedError:
-            return Screen.height(100)
-        }
+        return Screen.height(100)
     }
 }

--- a/Roomie/Roomie/Global/Security/Interceptor.swift
+++ b/Roomie/Roomie/Global/Security/Interceptor.swift
@@ -60,7 +60,7 @@ final class Interceptor: RequestInterceptor {
                 switch error {
                 case .noRefreshToken, .refreshTokenExpired, .userNotFound:
                     NotificationCenter.default.post(name: Notification.shouldLogout, object: nil)
-                    await Toast.show(message: "세션이 만료되었어요. 다시 로그인해주세요")
+                    await Toast.show(message: "세션이 만료되었어요. 다시 로그인해주세요", bottomInset: Screen.height(20))
                     break
                 case .reissueFailed:
                     await Toast.show(message: "서버 오류입니다. 다시 시도해주세요")

--- a/Roomie/Roomie/Global/Security/Interceptor.swift
+++ b/Roomie/Roomie/Global/Security/Interceptor.swift
@@ -60,7 +60,6 @@ final class Interceptor: RequestInterceptor {
                 switch error {
                 case .noRefreshToken, .refreshTokenExpired, .userNotFound:
                     NotificationCenter.default.post(name: Notification.shouldLogout, object: nil)
-                    await Toast.show(.sessionExpired)
                     break
                 case .reissueFailed:
                     await Toast.show(.serverError)

--- a/Roomie/Roomie/Global/Security/Interceptor.swift
+++ b/Roomie/Roomie/Global/Security/Interceptor.swift
@@ -60,19 +60,19 @@ final class Interceptor: RequestInterceptor {
                 switch error {
                 case .noRefreshToken, .refreshTokenExpired, .userNotFound:
                     NotificationCenter.default.post(name: Notification.shouldLogout, object: nil)
-                    await Toast.show(message: "세션이 만료되었어요. 다시 로그인해주세요", bottomInset: Screen.height(20))
+                    await Toast.show(.sessionExpired)
                     break
                 case .reissueFailed:
-                    await Toast.show(message: "서버 오류입니다. 다시 시도해주세요")
+                    await Toast.show(.serverError)
                     break
                 case .unknownError:
-                    await Toast.show(message: "요청에 실패했습니다. 잠시 후 다시 시도해주세요")
+                    await Toast.show(.requestFailed)
                     break
                 }
                 
                 completion(.doNotRetryWithError(error))
             } catch {
-                await Toast.show(message: "예기치 못한 오류가 발생했어요")
+                await Toast.show(.unexpectedError)
                 completion(.doNotRetryWithError(error))
             }
         }

--- a/Roomie/Roomie/Global/Utils/Toast.swift
+++ b/Roomie/Roomie/Global/Utils/Toast.swift
@@ -57,7 +57,7 @@ private extension Toast {
 
 extension Toast {
     /// 화면의 최상단에 Toast 메시지를 표시합니다.
-    static func show(message: String, bottomInset: CGFloat = Screen.height(32)) {
+    static func show(message: String, bottomInset: CGFloat = Screen.height(100)) {
         guard let window = UIApplication.shared.connectedScenes
             .compactMap({ $0 as? UIWindowScene })
             .first?.windows

--- a/Roomie/Roomie/Global/Utils/Toast.swift
+++ b/Roomie/Roomie/Global/Utils/Toast.swift
@@ -57,8 +57,7 @@ private extension Toast {
 
 extension Toast {
     /// 화면의 최상단에 Toast 메시지를 표시합니다.
-    /// bottomInset 기본 값 Screen.height(100)은 하단 TabBar 위에 위치하도록 합니다.
-    static func show(message: String, bottomInset: CGFloat = Screen.height(100)) {
+    static func show(_ toastType: ToastType) {
         guard let window = UIApplication.shared.connectedScenes
             .compactMap({ $0 as? UIWindowScene })
             .first?.windows
@@ -68,6 +67,6 @@ extension Toast {
         
         let toast = Toast()
         toast.alpha = 0.0
-        toast.show(message: message, inset: bottomInset, view: window)
+        toast.show(message: toastType.message, inset: toastType.bottomInset, view: window)
     }
 }

--- a/Roomie/Roomie/Global/Utils/Toast.swift
+++ b/Roomie/Roomie/Global/Utils/Toast.swift
@@ -57,14 +57,15 @@ private extension Toast {
 
 extension Toast {
     /// 화면의 최상단에 Toast 메시지를 표시합니다.
+    /// bottomInset 기본 값 Screen.height(100)은 하단 TabBar 위에 위치하도록 합니다.
     static func show(message: String, bottomInset: CGFloat = Screen.height(100)) {
         guard let window = UIApplication.shared.connectedScenes
             .compactMap({ $0 as? UIWindowScene })
             .first?.windows
             .first(where: { $0.isKeyWindow }) else {
-                return
+            return
         }
-
+        
         let toast = Toast()
         toast.alpha = 0.0
         toast.show(message: message, inset: bottomInset, view: window)

--- a/Roomie/Roomie/Presentation/OnBoarding/ViewController/LoginViewController.swift
+++ b/Roomie/Roomie/Presentation/OnBoarding/ViewController/LoginViewController.swift
@@ -80,11 +80,7 @@ private extension LoginViewController {
             .receive(on: RunLoop.main)
             .sink { isSucceed in
                 if isSucceed {
-                    NotificationCenter.default.post(
-                        name: Notification.shouldLogin,
-                        object: nil,
-                        userInfo: ["manualLogin": true]
-                    )
+                    NotificationCenter.default.post(name: Notification.shouldLogin, object: nil)
                 }
             }
             .store(in: cancelBag)

--- a/Roomie/Roomie/Presentation/OnBoarding/ViewController/LoginViewController.swift
+++ b/Roomie/Roomie/Presentation/OnBoarding/ViewController/LoginViewController.swift
@@ -18,9 +18,7 @@ final class LoginViewController: BaseViewController {
     
     private let rootView = LoginView()
     
-    private let kakaoLoginButtonTapSubject = PassthroughSubject<Void, Never>()
-    
-    private let appleLoginButtonTapSubject = PassthroughSubject<Void, Never>()
+    private let loginButtonTapSubject = PassthroughSubject<SocialType, Never>()
     
     private let viewModel: LoginViewModel
     
@@ -54,7 +52,7 @@ final class LoginViewController: BaseViewController {
             .tapPublisher
             .sink { [weak self] in
                 guard let self = self else { return }
-                self.kakaoLoginButtonTapSubject.send()
+                self.loginButtonTapSubject.send(.kakao)
             }
             .store(in: cancelBag)
         
@@ -62,7 +60,7 @@ final class LoginViewController: BaseViewController {
             .tapPublisher
             .sink { [weak self] in
                 guard let self else { return }
-                self.appleLoginButtonTapSubject.send()
+                self.loginButtonTapSubject.send(.apple)
             }
             .store(in: cancelBag)
     }
@@ -73,8 +71,7 @@ final class LoginViewController: BaseViewController {
 private extension LoginViewController {
     func bindViewModel() {
         let input = LoginViewModel.Input(
-            kakaoLoginButtonTapSubject: kakaoLoginButtonTapSubject.eraseToAnyPublisher(),
-            appleLoginButtonTapSubject: appleLoginButtonTapSubject.eraseToAnyPublisher()
+            loginButtonTapSubject: loginButtonTapSubject.eraseToAnyPublisher()
         )
         
         let output = viewModel.transform(from: input, cancelBag: cancelBag)

--- a/Roomie/Roomie/Presentation/OnBoarding/ViewModel/LoginViewModel.swift
+++ b/Roomie/Roomie/Presentation/OnBoarding/ViewModel/LoginViewModel.swift
@@ -67,7 +67,6 @@ private extension LoginViewModel {
     func saveTokens(accessToken: String, refreshToken: String) {
         TokenManager.shared.saveTokens(accessToken: accessToken, refreshToken: refreshToken)
         isLoginSucceedSubject.send(true)
-        NotificationCenter.default.post(name: Notification.shouldLogin, object: nil)
     }
     
     func performAppleLogin() {


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #182 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 소셜 타입을 적용했습니다
- Toast 코드를 수정했습니다
- 그리고 로그인 성공, 세션 만료 시 Toast를 삭제했습니다! 

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### 소셜 타입 적용에 따른 로그인뷰컨 코드 수정

<기존 코드 로직>
```swift
private let kakaoLoginButtonTapSubject = PassthroughSubject<Void, Never>()
private let appleLoginButtonTapSubject = PassthroughSubject<Void, Never>()
```
kakao 또는 apple 로그인 버튼에 각각 다른 subject가 붙어 있었습니닷
<br>

<수정한 로직>
```swift
enum SocialType: String {
    case kakao = "KAKAO"
    case apple = "APPLE"
}
```
수연이가 추가한 코드에 원시값 추가하였어요!

```swift
private let loginButtonTapSubject = PassthroughSubject<SocialType, Never>()
```
그리고 kakao, apple 로그인 버튼을 하나의 subject로 통일하고 `SocialType`을 방출하도록 수정하였습니다

```swift
func transform(from input: Input, cancelBag: CancelBag) -> Output {
    input.loginButtonTapSubject
        .sink { [weak self] socialType in
            guard let self else { return }
            switch socialType {
            case .kakao:
                self.performKakaoLogin()
            case .apple:
                self.performAppleLogin()
            }
        }
        .store(in: cancelBag)
    
    let isLoginSucceed = isLoginSucceedSubject.eraseToAnyPublisher()
    
    return Output(
        isLoginSucceedSubject: isLoginSucceed
    )
}
```
viewModel에서는 `SocialType`을 통해 분기처리하여 각 함수를 호출하도록 했습니다!
(수연이가 작성해두었던 kakao로그인 코드는 모두 `performKakaoLogin()`함수에 복붙해놨어욤)
<br>

### 전역 Toast 함수 코드 수정
조금 더 확장성이 좋게 수정하였습니다
<br>

<기존 코드>
```swift
extension Toast {
    /// 화면의 최상단에 Toast 메시지를 표시합니다.
    static func show(message: String, bottomInset: CGFloat = Screen.height(100)) {
        // ...
        toast.show(message: message, inset: bottomInset, view: window)
    }
}
```

수정 전에는 static func 파라미터로 `message`, `inset`값을 다 받았는데
호출 부분에서 이 모든 것을 관리하는 것이 비효율적이라고 판단하였습니다
<br>

<수정 후>
```swift
enum ToastType {
    case serverError
    case requestFailed
    case unexpectedError
    
    var message: String {
        switch self {
        case .serverError:
            return "서버 오류입니다. 다시 시도해주세요"
        case .requestFailed:
            return "요청에 실패했습니다. 잠시 후 다시 시도해주세요"
        case .unexpectedError:
            return "예기치 못한 오류가 발생했어요"
        }
    }
    
    var bottomInset: CGFloat {
        switch self {
        case .serverError, .requestFailed, .unexpectedError:
            return Screen.height(100)
        }
    }
}
```
```swift
extension Toast {
    /// 화면의 최상단에 Toast 메시지를 표시합니다.
    static func show(_ toastType: ToastType) {
				// ...
        toast.show(message: toastType.message, inset: toastType.bottomInset, view: window)
    }
}
```

수정 후 `ToastType` enum에서 `message`와 `inset`을 한번에 관리하고
static func에서 파라미터로 이 타입만 받아도 되게 수정했어요