### PR TITLE
[feat/#183] 관심지역 위치 설정 API 연결

### DIFF
--- a/Roomie/Roomie/Global/Enums/SocialType.swift
+++ b/Roomie/Roomie/Global/Enums/SocialType.swift
@@ -5,7 +5,7 @@
 //  Created by 예삐 on 6/5/25.
 //
 
-enum SocialType: String {
+enum SocialType: String, Equatable {
     case kakao = "KAKAO"
     case apple = "APPLE"
 }

--- a/Roomie/Roomie/Network/DTO/Users/UserLocationResponseDTO.swift
+++ b/Roomie/Roomie/Network/DTO/Users/UserLocationResponseDTO.swift
@@ -1,0 +1,14 @@
+//
+//  UserLocationResponseDTO.swift
+//  Roomie
+//
+//  Created by MaengKim on 6/27/25.
+//
+
+import Foundation
+
+struct UserLocationResponseDTO: ResponseModelType {
+    let latitude: Double
+    let longitude: Double
+    let location: String
+}

--- a/Roomie/Roomie/Network/DTO/Users/UserLocationResponseDTO.swift
+++ b/Roomie/Roomie/Network/DTO/Users/UserLocationResponseDTO.swift
@@ -8,7 +8,6 @@
 import Foundation
 
 struct UserLocationResponseDTO: ResponseModelType {
-    let latitude: Double
-    let longitude: Double
+    let latitude, longitude: Double
     let location: String
 }

--- a/Roomie/Roomie/Network/Service/HomeService.swift
+++ b/Roomie/Roomie/Network/Service/HomeService.swift
@@ -55,6 +55,10 @@ extension HomeService: HomeServiceProtocol {
     func fetchLocationSearchData(query: String) async throws -> BaseResponseBody<MapSearchResponseDTO>? {
         return try await self.request(with: .fetchLocationSearchData(query: query))
     }
+    
+    func fetchUserLocation(latitude: Double, longitude: Double, location: String) async throws -> BaseResponseBody<UserLocationResponseDTO>? {
+        return try await self.request(with: .fetchUserLocation(latitude: latitude, longitude: longitude, location: location))
+    }
 }
 
 final class MockHomeService: HomeServiceProtocol {
@@ -124,6 +128,11 @@ final class MockHomeService: HomeServiceProtocol {
     
     func updatePinnedHouse(houseID: Int) async throws -> BaseResponseBody<PinnedResponseDTO>? {
         let mockData: PinnedResponseDTO = PinnedResponseDTO(isPinned: false)
+        return BaseResponseBody(code: 200, message: "", data: mockData)
+    }
+    
+    func fetchUserLocation(latitude: Double, longitude: Double, location: String) async throws -> BaseResponseBody<UserLocationResponseDTO>? {
+        let mockData: UserLocationResponseDTO = UserLocationResponseDTO(latitude: 11, longitude: 11, location: "MOCK")
         return BaseResponseBody(code: 200, message: "", data: mockData)
     }
 }

--- a/Roomie/Roomie/Network/Service/HomeService.swift
+++ b/Roomie/Roomie/Network/Service/HomeService.swift
@@ -132,7 +132,11 @@ final class MockHomeService: HomeServiceProtocol {
     }
     
     func fetchUserLocation(latitude: Double, longitude: Double, location: String) async throws -> BaseResponseBody<UserLocationResponseDTO>? {
-        let mockData: UserLocationResponseDTO = UserLocationResponseDTO(latitude: 11, longitude: 11, location: "MOCK")
+        let mockData: UserLocationResponseDTO = UserLocationResponseDTO(
+            latitude: 11,
+            longitude: 11,
+            location: "MOCK"
+        )
         return BaseResponseBody(code: 200, message: "", data: mockData)
     }
 }

--- a/Roomie/Roomie/Network/TargetType/HomeTargetType.swift
+++ b/Roomie/Roomie/Network/TargetType/HomeTargetType.swift
@@ -13,6 +13,7 @@ enum HomeTargetType {
     case fetchUserHomeData
     case fetchLocationSearchData(query: String)
     case updatePinnedHouse(houseID: Int)
+    case fetchUserLocation(latitude: Double, longitude: Double, location: String)
 }
 
 extension HomeTargetType: TargetType {
@@ -28,6 +29,8 @@ extension HomeTargetType: TargetType {
             return "/locations"
         case .updatePinnedHouse(houseID: let houseID):
             return "/houses/\(houseID)/pins"
+        case .fetchUserLocation:
+            return "users/location"
         }
     }
     
@@ -39,6 +42,8 @@ extension HomeTargetType: TargetType {
             return .patch
         case .fetchLocationSearchData:
             return .get
+        case .fetchUserLocation:
+            return .patch
         }
     }
     
@@ -46,6 +51,11 @@ extension HomeTargetType: TargetType {
         switch self {
         case .fetchLocationSearchData(let query):
             return .requestParameters(parameters: ["q": query], encoding: URLEncoding.queryString)
+        case .fetchUserLocation(let lat, let lng, let location):
+            return .requestParameters(
+                parameters: ["latitude": lat, "longitude": lng, "location": location],
+                encoding: JSONEncoding.default
+            )
         default:
             return .requestPlain
         }

--- a/Roomie/Roomie/Presentation/Home/ServiceProtocol/HomeServiceProtocol.swift
+++ b/Roomie/Roomie/Presentation/Home/ServiceProtocol/HomeServiceProtocol.swift
@@ -13,4 +13,6 @@ protocol HomeServiceProtocol {
     func updatePinnedHouse(houseID: Int) async throws -> BaseResponseBody<PinnedResponseDTO>?
     
     func fetchLocationSearchData(query: String) async throws -> BaseResponseBody<MapSearchResponseDTO>?
+    
+    func fetchUserLocation(latitude: Double, longitude: Double, location: String) async throws -> BaseResponseBody<UserLocationResponseDTO>?
 }

--- a/Roomie/Roomie/Presentation/Home/ViewController/HomeViewController.swift
+++ b/Roomie/Roomie/Presentation/Home/ViewController/HomeViewController.swift
@@ -291,9 +291,6 @@ private extension HomeViewController {
         
         locationLabel.do {
             $0.setText(location, style: .title2, color: .grayscale10)
-            $0.numberOfLines = 1
-            $0.setContentHuggingPriority(.defaultLow, for: .horizontal)
-            $0.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
         }
         
         dropDownImageView.snp.makeConstraints {
@@ -313,11 +310,10 @@ private extension HomeViewController {
             $0.edges.equalToSuperview()
         }
         
-        locationButton.sizeToFit()
         locationButton.snp.makeConstraints {
             $0.height.equalTo(22)
-            $0.width.equalTo(Screen.width(66))
         }
+        locationButton.sizeToFit()
         
         let locationBarButton = UIBarButtonItem(customView: locationButton)
         

--- a/Roomie/Roomie/Presentation/Home/ViewController/HomeViewController.swift
+++ b/Roomie/Roomie/Presentation/Home/ViewController/HomeViewController.swift
@@ -279,13 +279,13 @@ private extension HomeViewController {
         
         locationButton.subviews.forEach { $0.removeFromSuperview() }
         
-        let locationLabel = UILabel()
         let likedButton = UIBarButtonItem(
             image: .icnHeartLine24,
             style: .plain,
             target: self,
             action: #selector(wishLishButtonDidTap)
         )
+        let locationLabel = UILabel()
         let dropDownImageView = UIImageView(image: .icnArrowDownFilled16)
         let locationButtonStack = UIStackView()
         
@@ -390,7 +390,8 @@ extension HomeViewController: UICollectionViewDelegateFlowLayout {
         _ collectionView: UICollectionView,
         didSelectItemAt indexPath: IndexPath
     ) {
-        guard let houseID = viewModel.homeDataSubject.value?.recentlyViewedHouses[indexPath.item].houseID else { return }
+        guard let houseID = viewModel.homeDataSubject.value?.recentlyViewedHouses[indexPath.item].houseID
+        else { return }
         let houseDetailViewController = HouseDetailViewController(
             viewModel: HouseDetailViewModel(houseID: houseID, service: HousesService())
         )

--- a/Roomie/Roomie/Presentation/Home/ViewController/LocationSearchViewController.swift
+++ b/Roomie/Roomie/Presentation/Home/ViewController/LocationSearchViewController.swift
@@ -11,7 +11,7 @@ import Combine
 import CombineCocoa
 
 protocol LocationSearchSheetViewControllerDelegate: AnyObject {
-    func didSelectLocation(location: String, lat: Double, lng: Double)
+    func didSelectLocation(location: String, latitude: Double, longitude: Double)
 }
 
 final class LocationSearchSheetViewController: BaseViewController {
@@ -34,7 +34,7 @@ final class LocationSearchSheetViewController: BaseViewController {
     
     private let searchTextFieldEnterSubject = PassthroughSubject<String, Never>()
     
-    private let locationDidSelectSubject = PassthroughSubject<String, Never>()
+    private let locationDidSelectSubject = PassthroughSubject<(Double, Double, String), Never>()
     
     private let viewWillAppearSubject = PassthroughSubject<Void, Never>()
     
@@ -190,16 +190,11 @@ extension LocationSearchSheetViewController: UICollectionViewDelegateFlowLayout 
         _ collectionView: UICollectionView,
         didSelectItemAt indexPath: IndexPath
     ) {
-        let selectedLocation = dataSource.itemIdentifier(for: indexPath)
-        if let location = selectedLocation {
-            self.locationDidSelectSubject.send(location.address)
-        }
-        
         if let selectedLocation = dataSource.itemIdentifier(for: indexPath) {
             delegate?.didSelectLocation(
-                location: selectedLocation.location,
-                lat: selectedLocation.x,
-                lng: selectedLocation.y
+                location: selectedLocation.address,
+                latitude: selectedLocation.x,
+                longitude: selectedLocation.y
             )
         }
         self.navigationController?.popViewController(animated: true)


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #183 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 관심 지역 위치 설정 API를 연결했습니다.

|    구현 내용    |   iPhone 14 pro   |  
| :-------------: | :----------: | 
| 관심지역 위치 설정 API 연결 | <video src = "https://github.com/user-attachments/assets/640e0625-ef5f-460c-bc13-fbdeb755f8b8" width ="250"> | 

## 💻 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### 네비바 subView 겹치는 문제

- setNavigationBar가 계속 호출되며 사용자가 설정하는 locationLabel이 겹쳐서 보였습니다. 이에 네비바 설정해주는 함수 상단에 subView를 제거하는 코드를 추가하였습니다🍃

<details>
<summary>homeViewController</summary>

```swift
locationButton.subviews.forEach { $0.removeFromSuperview() }
```
</details>

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
못생긴 블랙모드 대응은 빠르게 머지된 후 처리하겠습니더.. ㅎㅎ..
아요루미야 고생햇두. 너희 둘은 진쯔. 미쳣다 !! (positive)