### PR TITLE
[chore/#170] 온보딩 뷰 스와이프 제스처 수정

### DIFF
--- a/Roomie/Roomie/Presentation/Home/ViewController/HomeViewController.swift
+++ b/Roomie/Roomie/Presentation/Home/ViewController/HomeViewController.swift
@@ -178,7 +178,7 @@ private extension HomeViewController {
                 guard let self else { return }
                 self.rootView.nameLabel.text = data.nickname
                 self.setHomeNavigationBar(locaton: data.location)
-                self.rootView.subGreetingLabel.updateText("루미가 \(data.nickname)님의 완벽한 집을\n찾아드릴게요.")
+                self.rootView.subGreetingLabel.updateText("루미가 \(data.nickname) 님의 완벽한 집을\n찾아드릴게요.")
             }
             .store(in: cancelBag)
         

--- a/Roomie/Roomie/Presentation/Home/ViewController/HomeViewController.swift
+++ b/Roomie/Roomie/Presentation/Home/ViewController/HomeViewController.swift
@@ -178,7 +178,7 @@ private extension HomeViewController {
                 guard let self else { return }
                 self.rootView.nameLabel.text = data.nickname
                 self.setHomeNavigationBar(locaton: data.location)
-                self.rootView.subGreetingLabel.updateText("루미가 \(data.nickname) 님의 완벽한 집을\n찾아드릴게요.")
+                self.rootView.subGreetingLabel.updateText("루미가 \(data.nickname)님의 완벽한 집을\n찾아드릴게요.")
             }
             .store(in: cancelBag)
         

--- a/Roomie/Roomie/Presentation/OnBoarding/ViewController/LoginViewController.swift
+++ b/Roomie/Roomie/Presentation/OnBoarding/ViewController/LoginViewController.swift
@@ -44,6 +44,8 @@ final class LoginViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        navigationController?.interactivePopGestureRecognizer?.isEnabled = false
+        
         bindViewModel()
     }
     

--- a/Roomie/Roomie/Presentation/OnBoarding/ViewController/OnBoardingViewController.swift
+++ b/Roomie/Roomie/Presentation/OnBoarding/ViewController/OnBoardingViewController.swift
@@ -30,6 +30,8 @@ final class OnBoardingViewController: BaseViewController {
     
     private var type: OnBoardingType?
     
+    private var currentIndex: Int = 0
+    
     // MARK: - UIComponent
     
     private let startButton = UIButton(type: .system)
@@ -107,7 +109,7 @@ private extension OnBoardingViewController {
     func setPageViewController() {
         addChild(pageViewController)
         view.addSubview(pageViewController.view)
-        
+
         pageViewController.view.addSubview(startButton)
         startButton.snp.makeConstraints{
             $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(45)
@@ -115,9 +117,13 @@ private extension OnBoardingViewController {
             $0.width.equalTo(Screen.width(335))
             $0.height.equalTo(Screen.height(58))
         }
-        
+
         pageViewController.didMove(toParent: self)
         pageViewController.setViewControllers([pages[0]], direction: .forward, animated: true)
+        
+        if let scrollView = pageViewController.view.subviews.first(where: { $0 is UIScrollView }) as? UIScrollView {
+            scrollView.delegate = self
+        }
     }
     
     func setPageIndicators() {
@@ -194,9 +200,20 @@ extension OnBoardingViewController:
                             transitionCompleted completed: Bool) {
         guard let currentViewController = pageViewController.viewControllers?.first,
             let currentView = currentViewController.view as? OnBoardingStepView,
-            let type = currentView.type else {
+            let type = currentView.type,
+        let index = OnBoardingType.allCases.firstIndex(of: type)
+        else {
             return
         }
+        
+        currentIndex = index
         updatePageIndicators(for: type)
+    }
+}
+
+extension OnBoardingViewController: UIScrollViewDelegate {
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        let isEdgePage = (currentIndex == 0) || (currentIndex == OnBoardingType.allCases.count - 1)
+        scrollView.bounces = !isEdgePage
     }
 }


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #170 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 온보딩 뷰 앞 뒤로 bounce 효과를 제거하였습니다. 
- 로그인 뷰에서 뒤로가기 제스처를 막아두었습니다.
- 홈 뷰에서 닉네임 라벨 사이 공백을 제거하였습니다.

|    구현 내용    |   iPhone 14 pro   |   
| :-------------: | :----------: | 
| 온보딩 뷰 | <video src = "https://github.com/user-attachments/assets/1940052a-ab40-45c8-819c-cceac0e1bf75" width ="250"> | 
| 로그인 뷰 | <video src = "https://github.com/user-attachments/assets/fc2bb6c1-c0a0-48fb-a660-b958d9c13766" width ="250"> | 

## 📚 참고자료
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
🔗 https://ios-development.tistory.com/1257

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
홈 뷰에서 로그인 뷰로 넘어가는 제스처도 막으려고 했는데 안 넘어가더라구요..! 그래서 코드 수정은 따로 안 해두었습니다 !
홈 뷰에서 닉네임 라벨 사이 공백이 있어서 해당 부분도 제거해서 같이 올렸습니닷