### PR TITLE
[feat] 필터 뷰 기존 필터 내역 적용

### DIFF
--- a/Roomie/Roomie/Global/Components/DatePickerView.swift
+++ b/Roomie/Roomie/Global/Components/DatePickerView.swift
@@ -176,6 +176,5 @@ extension DatePickerView {
         datePicker.setDate(date, animated: false)
         let formatted = String.formattedDate(date: date)
         dateLabel.setText(formatted, style: .body1, color: .grayscale11)
-        delegate?.dateDidPick(date: formatted)
     }
 }

--- a/Roomie/Roomie/Global/Extensions/DateFormatter+.swift
+++ b/Roomie/Roomie/Global/Extensions/DateFormatter+.swift
@@ -1,0 +1,25 @@
+//
+//  DateFormatter+.swift
+//  Roomie
+//
+//  Created by 예삐 on 7/4/25.
+//
+
+import Foundation
+
+extension DateFormatter {
+    
+    static let inputSlash: DateFormatter = {
+        let formmater = DateFormatter()
+        formmater.locale = Locale(identifier: "en_US_POSIX")
+        formmater.dateFormat = "yyyy/MM/dd"
+        return formmater
+    }()
+    
+    static let outputHyphen: DateFormatter = {
+        let formmater = DateFormatter()
+        formmater.locale = Locale(identifier: "en_US_POSIX")
+        formmater.dateFormat = "yyyy-MM-dd"
+        return formmater
+    }()
+}

--- a/Roomie/Roomie/Global/Extensions/String+.swift
+++ b/Roomie/Roomie/Global/Extensions/String+.swift
@@ -9,11 +9,14 @@ import Foundation
 
 extension String {
     
+    /// "yyyy/MM/dd" 타입의 String을 Date로 변환
+    func toDate(inputFormat: DateFormatter = .inputSlash) -> Date? {
+        return inputFormat.date(from: self)
+    }
+    
     /// Date를 "yyyy/MM/dd" 타입의 String으로 변환
-    static func formattedDate(date: Date, format: String = "yyyy/MM/dd") -> String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = format
-        return formatter.string(from: date)
+    static func formattedDate(date: Date) -> String {
+        return DateFormatter.inputSlash.string(from: date)
     }
     
     /// "yyyy/MM/dd" 타입의 String을 Date 타입의 String으로 변환
@@ -22,14 +25,8 @@ extension String {
         inputFormat: String = "yyyy/MM/dd",
         outputFormat: String = "yyyy-MM-dd"
     ) -> String? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        
-        formatter.dateFormat = inputFormat
-        guard let date = formatter.date(from: dateString) else { return nil }
-        
-        formatter.dateFormat = outputFormat
-        return formatter.string(from: date)
+        guard let date = DateFormatter.inputSlash.date(from: dateString) else { return nil }
+        return DateFormatter.outputHyphen.string(from: date)
     }
     
     /// Int 타입을 받아 "123,456,789원" 형식의 String 값으로 변환

--- a/Roomie/Roomie/Presentation/MapFilter/Model/MapRequestModelBuilder.swift
+++ b/Roomie/Roomie/Presentation/MapFilter/Model/MapRequestModelBuilder.swift
@@ -12,15 +12,15 @@ extension MapRequestDTO {
         static let shared = MapRequestDTO.Builder()
         
         private var address: String? = nil
-        private var moodTag: [String] = []
-        private var depositRange: MinMaxRange = MinMaxRange(min: 0, max: 500)
-        private var monthlyRentRange: MinMaxRange = MinMaxRange(min: 0, max: 150)
-        private var genderPolicy: [String] = []
-        private var preferredDate: String? = nil
-        private var occupancyTypes: [String] = []
-        private var contractPeroid: [Int] = []
-        private var latitude: Double = 0
-        private var longitude: Double = 0
+        var moodTag: [String] = []
+        var depositRange: MinMaxRange = MinMaxRange(min: 0, max: 500)
+        var monthlyRentRange: MinMaxRange = MinMaxRange(min: 0, max: 150)
+        var genderPolicy: [String] = []
+        var preferredDate: String? = nil
+        var occupancyTypes: [String] = []
+        var contractPeriod: [Int] = []
+        var latitude: Double = 0
+        var longitude: Double = 0
         
         @discardableResult
         func setAddress(_ address: String?) -> Self {
@@ -65,8 +65,8 @@ extension MapRequestDTO {
         }
         
         @discardableResult
-        func setContractPeroid(_ contractPeriod: [Int]) -> Self {
-            self.contractPeroid = contractPeriod
+        func setContractPeriod(_ contractPeriod: [Int]) -> Self {
+            self.contractPeriod = contractPeriod
             return self
         }
         
@@ -91,7 +91,7 @@ extension MapRequestDTO {
                 genderPolicy: genderPolicy,
                 preferredDate: preferredDate,
                 occupancyTypes: occupancyTypes,
-                contractPeriod: contractPeroid,
+                contractPeriod: contractPeriod,
                 latitude: latitude,
                 longitude: longitude
             )

--- a/Roomie/Roomie/Presentation/MapFilter/ViewController/MapFilterViewController.swift
+++ b/Roomie/Roomie/Presentation/MapFilter/ViewController/MapFilterViewController.swift
@@ -334,78 +334,63 @@ private extension MapFilterViewController {
             }
             .store(in: cancelBag)
         
-        output.isGenderEmpty
-            .sink { [weak self] isEmpty in
+        output.selectedGenders
+            .sink { [weak self] genders in
                 guard let self = self else { return }
+                let filterRoomView = self.rootView.filterRoomView
                 
-                let buttons = [
-                    self.rootView.filterRoomView.maleButton,
-                    self.rootView.filterRoomView.femaleButton,
-                    self.rootView.filterRoomView.genderDivisionButton,
-                    self.rootView.filterRoomView.genderFreeButton
-                ]
+                filterRoomView.maleButton.isSelected = genders.contains("남성전용")
+                filterRoomView.femaleButton.isSelected = genders.contains("여성전용")
+                filterRoomView.genderDivisionButton.isSelected = genders.contains("남녀분리")
+                filterRoomView.genderFreeButton.isSelected = genders.contains("성별무관")
                 
-                if isEmpty {
-                    buttons.forEach { $0.isSelected = false }
-                }
             }
             .store(in: cancelBag)
         
-        output.isOccupancyTypeEmpty
-            .sink { [weak self] isEmpty in
+        output.selectedOccupancyTypes
+            .sink { [weak self] types in
                 guard let self = self else { return }
+                let filterRoomView = self.rootView.filterRoomView
                 
-                let buttons = [
-                    self.rootView.filterRoomView.singleButton,
-                    self.rootView.filterRoomView.doubleButton,
-                    self.rootView.filterRoomView.tripleButton,
-                    self.rootView.filterRoomView.quadButton
-                ]
-                
-                if isEmpty {
-                    buttons.forEach { $0.isSelected = false }
-                }
+                filterRoomView.singleButton.isSelected = types.contains("1인실")
+                filterRoomView.doubleButton.isSelected = types.contains("2인실")
+                filterRoomView.tripleButton.isSelected = types.contains("3인실")
+                filterRoomView.quadButton.isSelected = types.contains("4인실")
             }
             .store(in: cancelBag)
         
-        output.isMoodTagEmpty
-            .sink { [weak self] isEmpty in
+        output.selectedMoodTags
+            .sink { [weak self] tags in
                 guard let self = self else { return }
+                let filterRoomView = self.rootView.filterRoomView
                 
-                let buttons = [
-                    self.rootView.filterRoomView.calmButton,
-                    self.rootView.filterRoomView.livelyButton,
-                    self.rootView.filterRoomView.neatButton
-                ]
-                
-                if isEmpty {
-                    buttons.forEach { $0.isSelected = false }
-                }
+                filterRoomView.calmButton.isSelected = tags.contains("#차분한")
+                filterRoomView.livelyButton.isSelected = tags.contains("#활기찬")
+                filterRoomView.neatButton.isSelected = tags.contains("#깔끔한")
             }
             .store(in: cancelBag)
         
-        output.isContractPeriodEmpty
-            .sink { [weak self] isEmpty in
+        output.selectedContractPeriods
+            .sink { [weak self] periods in
                 guard let self = self else { return }
+                let filterPeriodView = self.rootView.filterPeriodView
                 
-                let buttons = [
-                    self.rootView.filterPeriodView.threeMonthButton,
-                    self.rootView.filterPeriodView.sixMonthButton,
-                    self.rootView.filterPeriodView.oneYearButton
-                ]
-                
-                if isEmpty {
-                    buttons.forEach { $0.isSelected = false }
-                }
+                filterPeriodView.threeMonthButton.isSelected = periods.contains(3)
+                filterPeriodView.sixMonthButton.isSelected = periods.contains(6)
+                filterPeriodView.oneYearButton.isSelected = periods.contains(12)
             }
             .store(in: cancelBag)
         
-        output.isPreferredDateEmpty
-            .sink { [weak self] isEmpty in
+        output.selectedPreferredDate
+            .receive(on: RunLoop.main)
+            .sink { [weak self] dateString in
                 guard let self = self else { return }
+                let filterPeriodView = self.rootView.filterPeriodView
                 
-                if isEmpty {
-                    self.rootView.filterPeriodView.preferredDatePickerView.dateLabel.setText(
+                if let dateString = dateString, let date = dateString.toDate() {
+                    filterPeriodView.preferredDatePickerView.setDate(date)
+                } else {
+                    filterPeriodView.preferredDatePickerView.dateLabel.setText(
                         String.formattedDate(date: Date()),
                         style: .body1,
                         color: .grayscale6

--- a/Roomie/Roomie/Presentation/MapFilter/ViewController/MapFilterViewController.swift
+++ b/Roomie/Roomie/Presentation/MapFilter/ViewController/MapFilterViewController.swift
@@ -382,7 +382,6 @@ private extension MapFilterViewController {
             .store(in: cancelBag)
         
         output.selectedPreferredDate
-            .receive(on: RunLoop.main)
             .sink { [weak self] dateString in
                 guard let self = self else { return }
                 let filterPeriodView = self.rootView.filterPeriodView

--- a/Roomie/Roomie/Presentation/MapFilter/ViewModel/MapFilterViewModel.swift
+++ b/Roomie/Roomie/Presentation/MapFilter/ViewModel/MapFilterViewModel.swift
@@ -29,6 +29,18 @@ final class MapFilterViewModel {
     
     init(builder: MapRequestDTO.Builder) {
         self.builder = builder
+        
+        depositMinSubject.send(builder.depositRange.min)
+        depositMaxSubject.send(builder.depositRange.max)
+        monthlyRentMinSubject.send(builder.monthlyRentRange.min)
+        monthlyRentMaxSubject.send(builder.monthlyRentRange.max)
+        
+        genderSubject.send(builder.genderPolicy)
+        occupancyTypeSubject.send(builder.occupancyTypes)
+        moodTagSubject.send(builder.moodTag)
+        
+        preferredDateSubject.send(builder.preferredDate)
+        contractPeriodSubject.send(builder.contractPeriod)
     }
 }
 
@@ -80,13 +92,13 @@ extension MapFilterViewModel: ViewModelType {
         let monthlyRentMaxText: AnyPublisher<Int, Never>
         
         /// 방 형태
-        let isGenderEmpty: AnyPublisher<Bool, Never>
-        let isOccupancyTypeEmpty: AnyPublisher<Bool, Never>
-        let isMoodTagEmpty: AnyPublisher<Bool, Never>
+        let selectedGenders: AnyPublisher<[String], Never>
+        let selectedOccupancyTypes: AnyPublisher<[String], Never>
+        let selectedMoodTags: AnyPublisher<[String], Never>
         
         /// 계약기간
-        let isPreferredDateEmpty: AnyPublisher<Bool, Never>
-        let isContractPeriodEmpty: AnyPublisher<Bool, Never>
+        let selectedPreferredDate: AnyPublisher<String?, Never>
+        let selectedContractPeriods: AnyPublisher<[Int], Never>
     }
     
     func transform(from input: Input, cancelBag: CancelBag) -> Output {
@@ -369,7 +381,7 @@ extension MapFilterViewModel: ViewModelType {
                     .setOccupancyTypes(occupancyTypeSubject.value)
                     .setMoodTag(moodTagSubject.value)
                     .setPreferredDate(preferredDateSubject.value)
-                    .setContractPeroid(contractPeriodSubject.value)
+                    .setContractPeriod(contractPeriodSubject.value)
             }
             .store(in: cancelBag)
         
@@ -385,24 +397,19 @@ extension MapFilterViewModel: ViewModelType {
         let monthlyRentMax = monthlyRentMaxSubject
             .eraseToAnyPublisher()
         
-        let isGenderEmpty = genderSubject
-            .map { $0.isEmpty }
+        let selectedGenders = genderSubject
             .eraseToAnyPublisher()
         
-        let isOccupancyTypeEmpty = occupancyTypeSubject
-            .map { $0.isEmpty }
+        let selectedOccupancyTypes = occupancyTypeSubject
             .eraseToAnyPublisher()
         
-        let isMoodTagEmpty = moodTagSubject
-            .map { $0.isEmpty }
+        let selectedMoodTags = moodTagSubject
             .eraseToAnyPublisher()
         
-        let isPreferredEmpty = preferredDateSubject
-            .map { $0?.isEmpty ?? true }
+        let selectedPreferredDate = preferredDateSubject
             .eraseToAnyPublisher()
         
-        let isContractPeriodEmpty = contractPeriodSubject
-            .map { $0.isEmpty }
+        let selectedContractPeriods = contractPeriodSubject
             .eraseToAnyPublisher()
         
         return Output(
@@ -410,11 +417,11 @@ extension MapFilterViewModel: ViewModelType {
             depositMaxText: depositMax,
             monthlyRentMinText: monthlyRentMin,
             monthlyRentMaxText: monthlyRentMax,
-            isGenderEmpty: isGenderEmpty,
-            isOccupancyTypeEmpty: isOccupancyTypeEmpty,
-            isMoodTagEmpty: isMoodTagEmpty,
-            isPreferredDateEmpty: isPreferredEmpty,
-            isContractPeriodEmpty: isContractPeriodEmpty
+            selectedGenders: selectedGenders,
+            selectedOccupancyTypes: selectedOccupancyTypes,
+            selectedMoodTags: selectedMoodTags,
+            selectedPreferredDate: selectedPreferredDate,
+            selectedContractPeriods: selectedContractPeriods
         )
     }
 }


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #202

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 필터 뷰에서 다른 뷰로 이동했을 경우에도 기존 필터 내역이 적용되도록 하는 기능을 구현했습니다. 앱잼 기간 때 필수 구현 사항은 아니었지만 제가 사용해보니 UX적으로 너무 불편해서 고쳤습니당. 😅

|    구현 내용    |   iPhone 16   |
| :-------------: | :----------: |
| 필터 뷰 | <img src = "https://github.com/user-attachments/assets/74e7cdd9-d010-4d52-9f0e-e680ffb96c1f" width ="250"> |

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
앱잼도 안 하는데 생활패턴이 앱잼 되어버렷어여 ..  괜히 이맘때 새벽에 개발 안 하고 있으니까 심심하당