### PR TITLE
[fix/#208] 셀 안 눌리는 오류 해결

### DIFF
--- a/Roomie/Roomie/Global/Base/BaseViewController.swift
+++ b/Roomie/Roomie/Global/Base/BaseViewController.swift
@@ -10,6 +10,9 @@ import UIKit
 import SnapKit
 
 class BaseViewController: UIViewController {
+    
+    private var viewsToIgnore: [UIView] = []
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -98,9 +101,12 @@ extension BaseViewController {
     }
     
     /// 화면 터치 시 키보드 내리기
-    func hideKeyboardWhenDidTap() {
+    func hideKeyboardWhenDidTap(excluding viewsToIgnore: [UIView] = []) {
+        self.viewsToIgnore = viewsToIgnore
+        
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
-        tapGesture.cancelsTouchesInView = true
+        tapGesture.cancelsTouchesInView = false
+        tapGesture.delegate = self
         view.addGestureRecognizer(tapGesture)
     }
     
@@ -122,5 +128,15 @@ extension BaseViewController: UIGestureRecognizerDelegate {
     /// 뒤로가기 제스쳐 삽입
     func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
         return navigationController?.viewControllers.count ?? 0 > 1
+    }
+    
+    /// 특정 뷰를 터치한 경우 키보드 dismiss 막기
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
+        for ignoredView in viewsToIgnore {
+            if let touchedView = touch.view, touchedView.isDescendant(of: ignoredView) {
+                return false
+            }
+        }
+        return true
     }
 }

--- a/Roomie/Roomie/Presentation/MyAccount/ViewController/NameEditViewController.swift
+++ b/Roomie/Roomie/Presentation/MyAccount/ViewController/NameEditViewController.swift
@@ -58,7 +58,7 @@ final class NameEditViewController: BaseViewController {
     }
     
     override func setAction() {
-        hideKeyboardWhenDidTap()
+        hideKeyboardWhenDidTap(excluding: [rootView.editButton])
         
         rootView.nameTextField
             .textPublisher

--- a/Roomie/Roomie/Presentation/MyAccount/ViewController/NicknameEditViewController.swift
+++ b/Roomie/Roomie/Presentation/MyAccount/ViewController/NicknameEditViewController.swift
@@ -58,7 +58,7 @@ final class NicknameEditViewController: BaseViewController {
     }
     
     override func setAction() {
-        hideKeyboardWhenDidTap()
+        hideKeyboardWhenDidTap(excluding: [rootView.editButton])
         
         rootView.nicknameTextField
             .textPublisher

--- a/Roomie/Roomie/Presentation/MyAccount/ViewController/PhoneNumberEditViewController.swift
+++ b/Roomie/Roomie/Presentation/MyAccount/ViewController/PhoneNumberEditViewController.swift
@@ -58,7 +58,7 @@ final class PhoneNumberEditViewController: BaseViewController {
     }
     
     override func setAction() {
-        hideKeyboardWhenDidTap()
+        hideKeyboardWhenDidTap(excluding: [rootView.editButton])
         
         rootView.phoneNumberTextField
             .controlEventPublisher(for: .editingChanged)


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #208

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- `tapGesture.cancelsTouchesInView = false`로 인해 셀 선택이 안 되던 이슈를 해결했습니다. 
- 특정 뷰를 터치한 경우 키보드 dismiss를 막는 함수를 구현하여 정보 수정 뷰에서 수정하기 버튼을 눌렀을 경우, `hideKeyboardWhenDidTap`가 무시되어 바로 화면이 전환됩니다.

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
제가 졸려서 스크린샷은 생략합니다. 저 믿으시죠?