### PR TITLE
[feat/#211] 서울 이외 지역 팝업 처리

### DIFF
--- a/Roomie/Roomie/Presentation/Home/ViewController/APPLELOVERCLUBViewController.swift
+++ b/Roomie/Roomie/Presentation/Home/ViewController/APPLELOVERCLUBViewController.swift
@@ -62,7 +62,7 @@ final class APPLELOVERCLUBViewController: BaseViewController {
     // MARK: - Function
     
     func loadURL() {
-        if let url = URL(string: "https://1401kms-70595.waveon.me") {
+        if let url = URL(string: "https://smore.im/quiz/mDC9DH57g2x") {
             let urlRequest = URLRequest(url: url)
             webView?.load(urlRequest)
         } else {

--- a/Roomie/Roomie/Presentation/Home/ViewController/LocationSearchViewController.swift
+++ b/Roomie/Roomie/Presentation/Home/ViewController/LocationSearchViewController.swift
@@ -138,6 +138,13 @@ private extension LocationSearchSheetViewController {
                 self.updateEmptyView(isEmpty: result.isEmpty)
             }
             .store(in: cancelBag)
+        
+        output.inValidLocation
+            .receive(on: DispatchQueue.main)
+            .sink { _ in 
+                Toast().show(message: "서울 이외의 지역은 아직 준비중이에요", inset: 23, view: self.rootView)
+            }
+            .store(in: cancelBag)
     }
     
     func createDiffableDataSource() -> UICollectionViewDiffableDataSource<Int, Location> {

--- a/Roomie/Roomie/Presentation/Home/ViewModel/HomeViewModel.swift
+++ b/Roomie/Roomie/Presentation/Home/ViewModel/HomeViewModel.swift
@@ -19,6 +19,7 @@ final class HomeViewModel {
     private let didTapHouseDataSubject = PassthroughSubject<Int, Never>()
     private let locationSearchDataSubject = PassthroughSubject<MapSearchResponseDTO, Never>()
     private let isSuccessSubject = PassthroughSubject<Bool, Never>()
+    private let invalidLocationSubject = PassthroughSubject<String, Never>()
     
     init(service: HomeServiceProtocol) {
         self.service = service
@@ -40,6 +41,7 @@ extension HomeViewModel: ViewModelType {
         let pinnedInfo: AnyPublisher<(Int,Bool), Never>
         let locationSearchData: AnyPublisher<MapSearchResponseDTO, Never>
         let isSuccess: AnyPublisher<Bool, Never>
+        let inValidLocation: AnyPublisher<String, Never>
     }
     
     func transform(from input: Input, cancelBag: CancelBag) -> Output {
@@ -114,7 +116,8 @@ extension HomeViewModel: ViewModelType {
             houseCount: houseCount,
             pinnedInfo: pinnedInfoData,
             locationSearchData: locationSearchData,
-            isSuccess: isSuccess
+            isSuccess: isSuccess,
+            inValidLocation: invalidLocationSubject.eraseToAnyPublisher()
         )
     }
 }
@@ -163,7 +166,16 @@ private extension HomeViewModel {
                     latitude: latitude,
                     longitude: longitude,
                     location: location
-                ), let _ = responseBody.data else { return }
+                ) else {
+                    isSuccessSubject.send(false)
+                    return
+                }
+                
+                if responseBody.data?.location.isEmpty == true {
+                    invalidLocationSubject.send(responseBody.message)
+                    return
+                }
+                
                 fetchHomeData()
                 isSuccessSubject.send(true)
             } catch {


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #211 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 위치 설정에서 서울 이외 지역을 선택하는 경우 분기 처리를 했습니다.
- 홈 화면에 있는 웹뷰 링크를 변경하였습니다.

|    구현 내용    |   iPhone 14 pro   |  
| :-------------: | :----------: | 
| 서울 이외 팝업 | <img src = "https://github.com/user-attachments/assets/a21512be-f8c5-427e-b4e3-b9edd794347d" width ="250"> | 


## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
서울 이외 지역을 선택하는 경우 서버에서 location을 빈 배열로 보내주는데 해당 부분 분기처리 했습니닷